### PR TITLE
fix(linux): harden runtime reliability and packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(KainoteLinux LANGUAGES C CXX)
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC OFF)
@@ -21,19 +24,17 @@ pkg_check_modules(FONTCONFIG REQUIRED IMPORTED_TARGET fontconfig)
 # frames the app composites (libass subtitles + progress bar) and presents through
 # the shared wx paint path, and gstreamer-audio provides linear volume.
 pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0 gstreamer-video-1.0 gstreamer-audio-1.0 gstreamer-app-1.0)
-pkg_get_variable(GSTREAMER_PLUGIN_DIR gstreamer-1.0 pluginsdir)
 
 # Link Boost statically on Linux so the built binary does not depend on the
 # exact distro Boost shared-library SONAME, e.g. libboost_filesystem.so.1.83.0.
 # Other system libraries remain dynamically linked through pkg-config/wxWidgets.
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS filesystem locale regex OPTIONAL_COMPONENTS system thread)
-find_program(MSGFMT_EXECUTABLE msgfmt)
-if(NOT MSGFMT_EXECUTABLE)
-    message(WARNING "msgfmt (gettext) not found; translation catalogs (Locale/*.mo) will not be built")
-endif()
+find_program(MSGFMT_EXECUTABLE msgfmt REQUIRED)
+find_program(TAR_EXECUTABLE tar REQUIRED)
+find_program(GZIP_EXECUTABLE gzip REQUIRED)
 add_compile_definitions(_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING _CRT_SECURE_NO_WARNINGS HAVE_DLL_EXPORT LINUX_BUILD KAINOTE_LINUX_BUILD)
-add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-include> $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/Kainote/platform.h> -Wno-deprecated-declarations -Wno-narrowing -Wno-unused-result $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-include> $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/Kainote/platform.h> -Wno-deprecated-declarations -Wno-narrowing -Wno-unused-result)
 add_executable(kainote
     Kainote/Demux.cpp
     Kainote/DialogueTextEditor.cpp
@@ -193,11 +194,6 @@ target_include_directories(kainote PRIVATE
     ${CMAKE_SOURCE_DIR}/Thirdparty/ffms2/src
 )
 
-if(GSTREAMER_PLUGIN_DIR)
-    set_property(SOURCE Kainote/AudioPlayerDSound.cpp Kainote/RendererGStreamer.cpp
-        APPEND PROPERTY COMPILE_DEFINITIONS "KAI_GST_PLUGIN_DIR=\"${GSTREAMER_PLUGIN_DIR}\"")
-endif()
-
 # Generate Kainote/gitparams.h from the current git HEAD before building.  Runs
 # every build but only rewrites the header when the commit/branch changes, so
 # config.cpp recompiles only when the version actually moves.
@@ -244,6 +240,11 @@ elseif(KAINOTE_SYSTEM_DICTIONARY_DIR AND EXISTS "${KAINOTE_SYSTEM_DICTIONARY_DIR
                 "${KAINOTE_SYSTEM_DICTIONARY_DIR}/en_US.dic"
                 "${KAINOTE_RUNTIME_DIR}/Dictionary"
     )
+else()
+    message(WARNING
+        "No en_US Hunspell dictionary was found. Kainote will build, but its "
+        "spell checker will have no default dictionary; install the distribution's "
+        "English Hunspell dictionary package and reconfigure.")
 endif()
 
 # Keep the build tree runnable by copying runtime data next to the executable.
@@ -269,6 +270,42 @@ add_custom_command(TARGET kainote POST_BUILD
     COMMAND ${CMAKE_COMMAND}
             -D KAINOTE_EXE=$<TARGET_FILE:kainote>
             -D RUNTIME_DIR=${KAINOTE_RUNTIME_DIR}
+            -D KAINOTE_BUILD_DIR=${CMAKE_BINARY_DIR}
             -P "${CMAKE_SOURCE_DIR}/cmake/CopyRuntimeDependencies.cmake"
     COMMENT "Copying Kainote runtime resources and bundled libraries"
+)
+
+# Package only explicitly selected runtime files.
+set(KAINOTE_PACKAGE_BASENAME "kainote-linux-${CMAKE_SYSTEM_PROCESSOR}")
+set(KAINOTE_PACKAGE_STAGE_PARENT "${CMAKE_BINARY_DIR}/package-stage")
+set(KAINOTE_PACKAGE_ARCHIVE
+    "${CMAKE_BINARY_DIR}/dist/${KAINOTE_PACKAGE_BASENAME}.tar.gz")
+file(MAKE_DIRECTORY "${KAINOTE_PACKAGE_STAGE_PARENT}")
+add_custom_target(kainote_linux_package
+    # Refresh the dependency manifest before every package.
+    COMMAND ${CMAKE_COMMAND}
+            -D KAINOTE_EXE=$<TARGET_FILE:kainote>
+            -D RUNTIME_DIR=$<TARGET_FILE_DIR:kainote>
+            -D KAINOTE_BUILD_DIR=${CMAKE_BINARY_DIR}
+            -P "${CMAKE_SOURCE_DIR}/cmake/CopyRuntimeDependencies.cmake"
+    COMMAND ${CMAKE_COMMAND}
+            -D KAINOTE_EXE=$<TARGET_FILE:kainote>
+            -D RUNTIME_DIR=$<TARGET_FILE_DIR:kainote>
+            -D SOURCE_DIR=${CMAKE_SOURCE_DIR}
+            -D BINARY_DIR=${CMAKE_BINARY_DIR}
+            -D STAGING_PARENT=${KAINOTE_PACKAGE_STAGE_PARENT}
+            -D PACKAGE_BASENAME=${KAINOTE_PACKAGE_BASENAME}
+            -D ARCHIVE_PATH=${KAINOTE_PACKAGE_ARCHIVE}
+            -D MSGFMT_EXECUTABLE=${MSGFMT_EXECUTABLE}
+            -D TAR_EXECUTABLE=${TAR_EXECUTABLE}
+            -D GZIP_EXECUTABLE=${GZIP_EXECUTABLE}
+            -D SYSTEM_DICTIONARY_DIR=${KAINOTE_SYSTEM_DICTIONARY_DIR}
+            -P "${CMAKE_SOURCE_DIR}/cmake/PackageLinuxRuntime.cmake"
+    DEPENDS kainote
+    BYPRODUCTS
+        "${KAINOTE_PACKAGE_ARCHIVE}"
+        "${KAINOTE_PACKAGE_ARCHIVE}.sha256"
+    WORKING_DIRECTORY "${KAINOTE_PACKAGE_STAGE_PARENT}"
+    COMMENT "Creating clean Kainote Linux runtime archive"
+    VERBATIM
 )

--- a/Kainote/AudioDisplay.cpp
+++ b/Kainote/AudioDisplay.cpp
@@ -752,7 +752,7 @@ void AudioDisplay::DrawInactiveLines() {
 		if (j == line_n) continue;
 		if (j < 0 || j >= grid->GetCount()) continue;
 		shade = grid->GetDialogue(j);
-		if (shade && !shade->isVisible)
+		if (!shade || !shade->isVisible)
 			continue;
 
 		// Get coordinates
@@ -967,7 +967,8 @@ void AudioDisplay::DrawTimescale() {
 // Waveform
 void AudioDisplay::DrawWaveform(bool weak) {
 	// Prepare Waveform
-	if (!weak || peak == nullptr || min == nullptr) {
+	bool rebuildWaveform = !weak || peak == nullptr || min == nullptr;
+	if (rebuildWaveform) {
 		if (peak) delete[] peak;
 		if (min) delete[] min;
 		peak = new int[w];
@@ -975,7 +976,7 @@ void AudioDisplay::DrawWaveform(bool weak) {
 	}
 
 	// Get waveform
-	if (!weak) {
+	if (rebuildWaveform) {
 		provider->GetWaveForm(min, peak, Position*samples, w, h, samples, scale);
 	}
 	d3dLine->Begin();

--- a/Kainote/AudioPlayerDSound.cpp
+++ b/Kainote/AudioPlayerDSound.cpp
@@ -159,10 +159,10 @@ void DirectSoundPlayer2Thread::Run()
 		return;
 	}
 
-	linuxState->pipeline = pipeline;
-	linuxState->appsrc = src;
 	{
 		std::lock_guard<std::mutex> lock(linuxState->mutex);
+		linuxState->pipeline = pipeline;
+		linuxState->appsrc = src;
 		linuxState->initialized = true;
 		linuxState->cv.notify_all();
 	}
@@ -213,25 +213,47 @@ void DirectSoundPlayer2Thread::Run()
 
 		long long frame = 0;
 		long long framesToWrite = 0;
+		double playbackVolume = 1.0;
 		{
 			std::lock_guard<std::mutex> lock(linuxState->mutex);
 			frame = linuxState->currentFrame;
 			framesToWrite = std::min<long long>(chunkFrames, std::max<long long>(0, requestEnd - frame));
+			playbackVolume = volume;
 		}
 
 		if (framesToWrite > 0) {
 			const gsize bytes = static_cast<gsize>(framesToWrite * bytesPerFrame);
 			GstBuffer *buf = gst_buffer_new_allocate(nullptr, bytes, nullptr);
+			if (!buf) {
+				std::lock_guard<std::mutex> lock(linuxState->mutex);
+				linuxState->failed = true;
+				linuxState->playing = false;
+				linuxState->failMessage = L"GStreamer could not allocate an audio buffer";
+				break;
+			}
 			// Let the provider decode straight into the GstBuffer memory (no
 			// intermediate copy), then hand it off; block=TRUE paces to the clock.
-			GstMapInfo map;
-			if (gst_buffer_map(buf, &map, GST_MAP_WRITE)) {
-				provider->GetBuffer(map.data, frame, framesToWrite, volume);
-				gst_buffer_unmap(buf, &map);
+			GstMapInfo map{};
+			if (!gst_buffer_map(buf, &map, GST_MAP_WRITE)) {
+				gst_buffer_unref(buf);
+				std::lock_guard<std::mutex> lock(linuxState->mutex);
+				linuxState->failed = true;
+				linuxState->playing = false;
+				linuxState->failMessage = L"GStreamer could not map an audio buffer";
+				break;
 			}
-			GstFlowReturn fr = gst_app_src_push_buffer(GST_APP_SRC(src), buf);
+			provider->GetBuffer(map.data, frame, framesToWrite, playbackVolume);
+			gst_buffer_unmap(buf, &map);
+			const GstFlowReturn flow = gst_app_src_push_buffer(GST_APP_SRC(src), buf);
 			std::lock_guard<std::mutex> lock(linuxState->mutex);
-			linuxState->currentFrame += framesToWrite;
+			if (flow == GST_FLOW_OK) {
+				linuxState->currentFrame += framesToWrite;
+			}
+			else if (linuxState->running) {
+				linuxState->failed = true;
+				linuxState->playing = false;
+				linuxState->failMessage = L"GStreamer audio pipeline stopped accepting data";
+			}
 		}
 		else {
 			guint64 level = 0;
@@ -260,9 +282,12 @@ void DirectSoundPlayer2Thread::Run()
 	}
 
 	gst_element_set_state(pipeline, GST_STATE_NULL);
+	{
+		std::lock_guard<std::mutex> lock(linuxState->mutex);
+		linuxState->pipeline = nullptr;
+		linuxState->appsrc = nullptr;
+	}
 	gst_object_unref(pipeline);
-	linuxState->pipeline = nullptr;
-	linuxState->appsrc = nullptr;
 }
 
 unsigned int DirectSoundPlayer2Thread::FillAndUnlockBuffers(unsigned char*, unsigned int, unsigned char*, unsigned int,
@@ -317,11 +342,20 @@ DirectSoundPlayer2Thread::DirectSoundPlayer2Thread(Provider *provider, int _Want
 DirectSoundPlayer2Thread::~DirectSoundPlayer2Thread()
 {
 	if (linuxState) {
+		GstElement *pipeline = nullptr;
 		{
 			std::lock_guard<std::mutex> lock(linuxState->mutex);
+			// Keep the pipeline alive while flushing blocked appsrc writes.
+			if (linuxState->pipeline)
+				pipeline = GST_ELEMENT(gst_object_ref(linuxState->pipeline));
 			linuxState->running = false;
 			linuxState->playing = false;
 			linuxState->cv.notify_all();
+		}
+		if (pipeline) {
+			gst_element_send_event(pipeline, gst_event_new_flush_start());
+			gst_element_set_state(pipeline, GST_STATE_NULL);
+			gst_object_unref(pipeline);
 		}
 		if (linuxState->thread.joinable())
 			linuxState->thread.join();
@@ -380,13 +414,15 @@ bool DirectSoundPlayer2Thread::IsPlaying()
 long long DirectSoundPlayer2Thread::GetStartFrame()
 {
 	CheckError();
+	std::lock_guard<std::mutex> lock(linuxState->mutex);
 	return start_frame;
 }
 
 int DirectSoundPlayer2Thread::GetCurrentMS()
 {
 	CheckError();
-	if (!IsPlaying()) return 0;
+	std::lock_guard<std::mutex> lock(linuxState->mutex);
+	if (!linuxState->playing) return 0;
 	return static_cast<int>(timeGetTime() - last_playback_restart);
 }
 
@@ -404,6 +440,7 @@ long long DirectSoundPlayer2Thread::GetCurrentFrame()
 long long DirectSoundPlayer2Thread::GetEndFrame()
 {
 	CheckError();
+	std::lock_guard<std::mutex> lock(linuxState->mutex);
 	return end_frame;
 }
 

--- a/Kainote/AudioSpectrum.cpp
+++ b/Kainote/AudioSpectrum.cpp
@@ -403,21 +403,25 @@ AudioSpectrumMultiThreading::AudioSpectrumMultiThreading(Provider *provider, std
 
 AudioSpectrumMultiThreading::~AudioSpectrumMultiThreading()
 {
-	if (ffttable) 
-		delete[] ffttable;
-	if (threads){
+	if (eventKillSelf)
 		SetEvent(eventKillSelf);
-		WaitForMultipleObjects(numThreads, threads, TRUE, 20000);
-		for (int i = 0; i < numThreads; i++){
-			CloseHandle(threads[i]);
-			CloseHandle(eventMakeCache[i]);
-			CloseHandle(eventCacheCopleted[i]);
+	if (threads) {
+		// Workers use these buffers, so join before freeing them.
+		for (int i = 0; i < numThreads; i++) {
+			if (threads[i])
+				WaitForSingleObject(threads[i], INFINITE);
 		}
-		CloseHandle(eventKillSelf);
-		delete[] threads;
-		delete[] eventMakeCache;
-		delete[] eventCacheCopleted;
+		for (int i = 0; i < numThreads; i++){
+			if (threads[i]) CloseHandle(threads[i]);
+			if (eventMakeCache && eventMakeCache[i]) CloseHandle(eventMakeCache[i]);
+			if (eventCacheCopleted && eventCacheCopleted[i]) CloseHandle(eventCacheCopleted[i]);
+		}
 	}
+	if (eventKillSelf) CloseHandle(eventKillSelf);
+	delete[] threads;
+	delete[] eventMakeCache;
+	delete[] eventCacheCopleted;
+	delete[] ffttable;
 }
 
 void AudioSpectrumMultiThreading::CreateCache(unsigned long _start, unsigned long _end)
@@ -518,4 +522,3 @@ void AudioSpectrumMultiThreading::SetAudio(unsigned long _start, int _len, FFT *
 }
 
 AudioSpectrumMultiThreading *AudioSpectrumMultiThreading::sthread = nullptr;
-

--- a/Kainote/AutoSaveOpen.cpp
+++ b/Kainote/AutoSaveOpen.cpp
@@ -134,12 +134,9 @@ void AutoSaveOpen::GenerateList()
 		return;
 	}
 
-	while (1) {
-		int result = FindNextFile(h, &data);
-		if (result == ERROR_NO_MORE_FILES || result == 0) { break; }
-		else if (data.nFileSizeLow == 0) { continue; }
-
+	do {
 		wxString fileName = wxString(data.cFileName);
+		if (fileName == L"." || fileName == L".." || data.nFileSizeLow == 0) { continue; }
 		wxString ext;
 		wxString rest = fileName.BeforeLast(L'.', &ext);
 		wxString fileNum;
@@ -177,7 +174,7 @@ void AutoSaveOpen::GenerateList()
 		else {
 			versions[findResult]->insert(std::pair<wxString, wxString>(accessStringTime, fileName));
 		}
-	}
+	} while (FindNextFile(h, &data));
 	FindClose(h);
 	if (!paths.GetCount()) {
 		KaiLog(_("Folder autozapisu jest pusty"));

--- a/Kainote/AutoSavesRemoving.cpp
+++ b/Kainote/AutoSavesRemoving.cpp
@@ -239,10 +239,9 @@ void AutoSavesRemoving::ClearByDate(int id)
 		return;
 	}
 
-	while (1) {
-		int result = FindNextFile(h, &data);
-		if (result == ERROR_NO_MORE_FILES || result == 0) { break; }
-		else if (data.nFileSizeLow == 0) { continue; }
+	do {
+		wxString fileName = wxString(data.cFileName);
+		if (fileName == L"." || fileName == L".." || data.nFileSizeLow == 0) { continue; }
 		SYSTEMTIME accessSystemTime;
 		SYSTEMTIME accessSystemUniversalTime;
 		FileTimeToSystemTime(&data.ftLastWriteTime, &accessSystemUniversalTime);
@@ -257,8 +256,8 @@ void AutoSavesRemoving::ClearByDate(int id)
 			accessSystemTime.wMonth == chosenTime.wMonth)
 			continue;
 		
-		paths.Add(path + data.cFileName);
-	}
+		paths.Add(path + fileName);
+	} while (FindNextFile(h, &data));
 
 	FindClose(h);
 

--- a/Kainote/Automation.cpp
+++ b/Kainote/Automation.cpp
@@ -760,13 +760,16 @@ namespace Auto{
 
 	bool LuaScript::CheckLastModified(bool check)
 	{
-		FILETIME ft;
+		FILETIME ft{};
 
 		HANDLE ffile = CreateFile(GetFilename().wc_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
 		if (ffile == INVALID_HANDLE_VALUE)
 			return false;
 
-		GetFileTime(ffile, 0, 0, &ft);
+		if (!GetFileTime(ffile, 0, 0, &ft)) {
+			CloseHandle(ffile);
+			return false;
+		}
 		CloseHandle(ffile);
 		if (check){
 			if (LowTime != ft.dwLowDateTime || HighTime != ft.dwHighDateTime){
@@ -822,8 +825,10 @@ namespace Auto{
 
 
 		lua_gc(L, LUA_GCCOLLECT, 0);
-		if (ps->Log == L"" && !hasMessage){ ps->lpd->closedialog = true; }
-		else{ ps->lpd->finished = true; }
+		if (ps && ps->lpd) {
+			if (ps->Log == L"" && !hasMessage){ ps->lpd->closedialog = true; }
+			else{ ps->lpd->finished = true; }
+		}
 
 		if (failed){ return (wxThread::ExitCode) 1; }
 		return 0;
@@ -1325,13 +1330,9 @@ namespace Auto{
 		}
 
 		wxWCharBuffer editorbuf = editor.c_str(), sfnamebuf = Filename.c_str();
-		wchar_t **cmdline = new wchar_t*[3];
-		cmdline[0] = editorbuf.data();
-		cmdline[1] = sfnamebuf.data();
-		cmdline[2] = 0;
+		wchar_t *cmdline[] = { editorbuf.data(), sfnamebuf.data(), nullptr };
 
 		long res = wxExecute(cmdline);
-		delete cmdline;
 
 		if (!res) {
 			KaiMessageBox(_("Nie można uruchomić edytora."), _("Błąd automatyzacji"), wxOK | wxICON_ERROR);

--- a/Kainote/Automation.h
+++ b/Kainote/Automation.h
@@ -93,7 +93,7 @@ namespace Auto {
 
 		void GetFeatureFunction(const char* function) const;
 
-		LuaFeature(lua_State* L) : L(L) { }
+		LuaFeature(lua_State* L) : myid(-2), L(L) { }
 	};
 
 
@@ -249,4 +249,3 @@ namespace Auto {
 		unsigned char* data = nullptr;
 	};
 }
-

--- a/Kainote/AutomationFileSystem.cpp
+++ b/Kainote/AutomationFileSystem.cpp
@@ -93,8 +93,8 @@ namespace Auto{
 		if(!SystemTimeToFileTime(&st, &ft))
 			throw wxString(L"SystemTimeToFileTime failed with error: " + ErrorString(GetLastError()));
 
-		scoped_holder<HANDLE, BOOL (__stdcall *)(HANDLE)>
-			h(CreateFile(file.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr), CloseHandle);
+		scoped_holder<HANDLE, decltype(&CloseHandle)>
+			h(CreateFile(file.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr), &CloseHandle);
 		// error handling etc.
 		if (!SetFileTime(h, nullptr, nullptr, &ft))
 			throw wxString(L"SetFileTime failed with error: " + ErrorString(GetLastError()));
@@ -133,22 +133,17 @@ namespace Auto{
 		bool operator==(DirectoryIterator const&) const;
 		bool operator!=(DirectoryIterator const& rhs) const { return !(*this == rhs); }
 		DirectoryIterator& operator++();
+		void Close();
 		std::string const& operator*() const { return value; }
 
 		DirectoryIterator(path const& p, std::string const& filter);
 		DirectoryIterator();
 		~DirectoryIterator();
-
-		template<typename T> void GetAll(T& cont);
+		DirectoryIterator(DirectoryIterator const&) = delete;
+		DirectoryIterator& operator=(DirectoryIterator const&) = delete;
 	};
 
-	static inline DirectoryIterator& begin(DirectoryIterator &it) { return it; }
 	static inline DirectoryIterator end(DirectoryIterator &) { return DirectoryIterator(); }
-
-	template<typename T>
-	inline void DirectoryIterator::GetAll(T& cont) {
-		copy(*this, end(*this), std::back_inserter(cont));
-	}
 
 	//struct DirectoryIterator::PrivData {
 	//	scoped_holder<HANDLE, BOOL (__stdcall *)(HANDLE)> h;//{INVALID_HANDLE_VALUE, FindClose};
@@ -169,7 +164,7 @@ namespace Auto{
 		}
 
 		value = wxString(data.cFileName).ToStdString();
-		while (value[0] == '.' && (value[1] == 0 || value[1] == '.'))
+		while (handle && (value == "." || value == ".."))
 			++*this;
 	}
 
@@ -182,15 +177,20 @@ namespace Auto{
 		if (handle && FindNextFile(handle, &data))
 			value = wxString(data.cFileName).ToStdString();
 		else {
-			//if(privdata){privdata.reset();}
-			//if(privdata){delete privdata; privdata=NULL;}
-			handle = NULL;
-			value.clear();
+			Close();
 		}
 		return *this;
 	}
 
-	DirectoryIterator::~DirectoryIterator() { if (handle){ FindClose(handle); handle=NULL; }}
+	void DirectoryIterator::Close() {
+		if (handle) {
+			FindClose(handle);
+			handle = NULL;
+		}
+		value.clear();
+	}
+
+	DirectoryIterator::~DirectoryIterator() { Close(); }
 
 	template<typename Func>
 	auto wrap(char **err, Func f) -> decltype(f()) {
@@ -249,7 +249,7 @@ namespace Auto{
 	}
 
 	void dir_close(DirectoryIterator &it) {
-		it = DirectoryIterator();
+		it.Close();
 	}
 
 	void dir_free(DirectoryIterator *it) {

--- a/Kainote/AutomationScriptReader.cpp
+++ b/Kainote/AutomationScriptReader.cpp
@@ -24,6 +24,8 @@
 #include <wx/log.h>
 
 #include <lauxlib.h>
+#include <string>
+#include <vector>
 
 namespace Auto {
 
@@ -31,37 +33,51 @@ namespace Auto {
 
 	bool LoadFile(lua_State *L, wxString const& filename) {
 		wxString script;
-		const char *constbuff;
-		char *buff;
-		int size;
+		std::string compatibilityBuffer;
+		std::vector<char> fileBuffer;
+		const char *buffer = "";
+		size_t size = 0;
 		bool compatybility = Options.GetBool(AUTOMATION_OLD_SCRIPTS_COMPATIBILITY);
 		if (compatybility){
 			OpenWrite ow;
 			if (!ow.FileOpen(filename, &script)){ return false; }
 			script.Replace("kainote", "aegisub");
 
-			constbuff = script.mb_str(wxConvUTF8).data();
-			size = strlen(constbuff);
+			wxCharBuffer encodedScript = script.mb_str(wxConvUTF8);
+			compatibilityBuffer.assign(encodedScript.data(), encodedScript.length());
+			buffer = compatibilityBuffer.data();
+			size = compatibilityBuffer.size();
 		}
 		else{
-			FILE *f = NULL;
-			f = _wfopen(filename.wc_str(), L"rb");
+			FILE *f = _wfopen(filename.wc_str(), L"rb");
 			if (!f){ return false; }
-			fseek(f, 0, SEEK_END);
-			size = ftell(f);
+			if (fseek(f, 0, SEEK_END) != 0) {
+				fclose(f);
+				return false;
+			}
+			long fileSize = ftell(f);
+			if (fileSize < 0) {
+				fclose(f);
+				return false;
+			}
 			rewind(f);
-			buff = new char[size];
-			size = fread(buff, 1, size, f);
+			fileBuffer.resize(static_cast<size_t>(fileSize));
+			size = fileBuffer.empty() ? 0 : fread(fileBuffer.data(), 1, fileBuffer.size(), f);
+			bool readSucceeded = size == fileBuffer.size();
 			fclose(f);
-			
-			if (size >= 3 && buff[0] == -17 && buff[1] == -69 && buff[2] == -65) {
-				buff += 3;
+			if (!readSucceeded) { return false; }
+
+			buffer = fileBuffer.empty() ? "" : fileBuffer.data();
+			if (size >= 3 && static_cast<unsigned char>(buffer[0]) == 0xEF &&
+				static_cast<unsigned char>(buffer[1]) == 0xBB &&
+				static_cast<unsigned char>(buffer[2]) == 0xBF) {
+				buffer += 3;
 				size -= 3;
 			}
 		}
 		//wxString name = filename.AfterLast('\\');
 		if (!filename.EndsWith("moon")){
-			bool ret = luaL_loadbuffer(L, (compatybility) ? constbuff : buff, size, filename.mb_str(wxConvUTF8).data()) == 0;
+			bool ret = luaL_loadbuffer(L, buffer, size, filename.mb_str(wxConvUTF8).data()) == 0;
 
 			return ret;
 
@@ -73,7 +89,7 @@ namespace Auto {
 
 		// Save the text we'll be loading for the line number rewriting in the
 		// error handling
-		lua_pushlstring(L, (compatybility) ? constbuff : buff, size);
+		lua_pushlstring(L, buffer, size);
 		lua_pushvalue(L, -1);
 		lua_setfield(L, LUA_REGISTRYINDEX, ("raw moonscript: " + filename).mb_str(wxConvUTF8).data());
 		

--- a/Kainote/AutomationToFile.cpp
+++ b/Kainote/AutomationToFile.cpp
@@ -250,13 +250,13 @@ namespace Auto{
 			lua_setfield(L, -2, "effect");
 
 			bool isTl = adial->TextTl != L"";
-			const char* textTl = adial->TextTl->mb_str(wxConvUTF8).data();
-			const char* text = adial->Text->mb_str(wxConvUTF8).data();
+			wxCharBuffer textTl = adial->TextTl->mb_str(wxConvUTF8);
+			wxCharBuffer text = adial->Text->mb_str(wxConvUTF8);
 
-			lua_pushstring(L, isTl? textTl : text);
+			lua_pushstring(L, isTl ? textTl.data() : text.data());
 			lua_setfield(L, -2, "text");
 			if (isTl) {
-				lua_pushstring(L, text);
+				lua_pushstring(L, text.data());
 				lua_setfield(L, -2, "text_translation");
 			}
 			lua_newtable(L);
@@ -1230,4 +1230,3 @@ namespace Auto{
 		return 0;
 	};
 }
-

--- a/Kainote/AutomationUtils.h
+++ b/Kainote/AutomationUtils.h
@@ -23,7 +23,7 @@ extern "C" {
 //#include <string>
 #include <vector>
 #include <memory>
-//#include <type_traits>
+#include <type_traits>
 
 
 struct tm;
@@ -59,7 +59,6 @@ namespace Auto{
 	class tagless_find_helper {
 		std::vector<std::pair<size_t, size_t>> blocks;
 		size_t start;
-		//upewniæ siê, ¿e ta klase bêdzie mia³a start na 0;
 		tagless_find_helper(){ start = 0; }
 	public:
 		/// Strip ASS override tags at or after `start` in `str`, and initialize
@@ -96,6 +95,13 @@ namespace Auto{
 	void preload_modules(lua_State *L);
 	//ffi
 	void do_register_lib_function(lua_State *L, const char *name, const char *type_name, void *func);
+	template<typename FunctionPointer>
+	void do_register_lib_function(lua_State *L, const char *name, const char *type_name, FunctionPointer func) {
+		static_assert(std::is_pointer_v<FunctionPointer>);
+		static_assert(std::is_function_v<std::remove_pointer_t<FunctionPointer>>);
+		// POSIX ABI bridge for LuaJIT FFI.
+		do_register_lib_function(L, name, type_name, reinterpret_cast<void *>(func));
+	}
 	void do_register_lib_table(lua_State *L, std::vector<const char *> types);
 
 	//static void register_lib_functions(lua_State *) {

--- a/Kainote/BidiConversion.cpp
+++ b/Kainote/BidiConversion.cpp
@@ -22,7 +22,91 @@
 #include <unicode/localpointer.h>
 #include <unicode/putil.h>
 #include <unicode/ushape.h>
+#include <unicode/ustring.h>
+#include <limits>
+#include <vector>
 //#include <windows.h>
+
+namespace {
+
+bool TransformBidiText(wxString* text,
+	UBiDiLevel inputLevel,
+	UBiDiOrder inputOrder,
+	UBiDiLevel outputLevel,
+	UBiDiOrder outputOrder,
+	uint32_t shapingOptions)
+{
+	if (!text || text->empty())
+		return text != nullptr;
+
+	const wxScopedCharBuffer utf8 = text->utf8_str();
+	if (!utf8.data() || utf8.length() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+		KaiLog(L"Cannot convert bidi text to UTF-8");
+		return false;
+	}
+
+	UErrorCode errorCode = U_ZERO_ERROR;
+	int32_t inputLength = 0;
+	u_strFromUTF8(nullptr, 0, &inputLength, utf8.data(), static_cast<int32_t>(utf8.length()), &errorCode);
+	if (errorCode != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(errorCode)) {
+		KaiLog(L"Cannot convert bidi text to UTF-16: " + wxString::FromUTF8(u_errorName(errorCode)));
+		return false;
+	}
+	if (inputLength > (std::numeric_limits<int32_t>::max() - 1) / 2) {
+		KaiLog(L"Bidi conversion text is too large");
+		return false;
+	}
+
+	errorCode = U_ZERO_ERROR;
+	std::vector<UChar> input(static_cast<size_t>(inputLength) + 1);
+	u_strFromUTF8(input.data(), static_cast<int32_t>(input.size()), &inputLength,
+		utf8.data(), static_cast<int32_t>(utf8.length()), &errorCode);
+	if (U_FAILURE(errorCode)) {
+		KaiLog(L"Cannot convert bidi text to UTF-16: " + wxString::FromUTF8(u_errorName(errorCode)));
+		return false;
+	}
+
+	UBiDiTransform* transform = ubiditransform_open(&errorCode);
+	if (U_FAILURE(errorCode) || !transform) {
+		KaiLog(L"Cannot initialize bidi conversion: " + wxString::FromUTF8(u_errorName(errorCode)));
+		return false;
+	}
+
+	// Unshaping may double the UTF-16 length.
+	const int32_t outputCapacity = inputLength * 2;
+	std::vector<UChar> output(static_cast<size_t>(outputCapacity) + 1);
+	const uint32_t outputLength = ubiditransform_transform(
+		transform, input.data(), inputLength, output.data(), outputCapacity,
+		inputLevel, inputOrder, outputLevel, outputOrder,
+		UBIDI_MIRRORING_OFF, shapingOptions, &errorCode);
+	ubiditransform_close(transform);
+	if (U_FAILURE(errorCode) || outputLength > static_cast<uint32_t>(outputCapacity)) {
+		KaiLog(L"Cannot transform bidi text: " + wxString::FromUTF8(u_errorName(errorCode)));
+		return false;
+	}
+
+	int32_t resultLength = 0;
+	errorCode = U_ZERO_ERROR;
+	u_strToUTF8(nullptr, 0, &resultLength, output.data(), static_cast<int32_t>(outputLength), &errorCode);
+	if (errorCode != U_BUFFER_OVERFLOW_ERROR && U_FAILURE(errorCode)) {
+		KaiLog(L"Cannot convert transformed bidi text to UTF-8: " + wxString::FromUTF8(u_errorName(errorCode)));
+		return false;
+	}
+
+	errorCode = U_ZERO_ERROR;
+	std::vector<char> result(static_cast<size_t>(resultLength) + 1);
+	u_strToUTF8(result.data(), static_cast<int32_t>(result.size()), &resultLength,
+		output.data(), static_cast<int32_t>(outputLength), &errorCode);
+	if (U_FAILURE(errorCode)) {
+		KaiLog(L"Cannot convert transformed bidi text to UTF-8: " + wxString::FromUTF8(u_errorName(errorCode)));
+		return false;
+	}
+
+	*text = wxString::FromUTF8(result.data(), static_cast<size_t>(resultLength));
+	return true;
+}
+
+} // namespace
 
 void ConvertToRTL(wxString* textin, wxString* textout)
 {
@@ -320,64 +404,16 @@ void ConvertToRTLCharsSpellchecker(wxString* textin, wxString* textout)
 
 void BIDIConvert(wxString* text)
 {
-	UErrorCode errorCode = U_ZERO_ERROR;
-
-	// Open a new UBiDiTransform.
-
-	UBiDiTransform* transform = ubiditransform_open(&errorCode);
-
-	// Run a transformation.
-	std::wstring wtext = text->ToStdWstring();
-
-	std::u16string text1(wtext.begin(), wtext.end());
-	size_t len = (text1.size() + 3) * 2;
-	UChar* text2 = (UChar*)malloc(len);
-	if (!text2) {
-		KaiLog(L"Cannot allocate bidi conversion text");
-		return;
-	}
-
-	ubiditransform_transform(transform, text1.data(), -1, text2, (len),
+	TransformBidiText(text,
 		UBIDI_RTL, UBIDI_LOGICAL, UBIDI_LTR, UBIDI_VISUAL,
-		UBIDI_MIRRORING_OFF, U_SHAPE_LETTERS_SHAPE, &errorCode);
-
-	ubiditransform_close(transform);
-	std::u16string result16(text2);
-	const wchar_t* result = reinterpret_cast<const wchar_t*>(result16.c_str());
-
-	(*text) = wxString(result);
-	free(text2);
+		U_SHAPE_LETTERS_SHAPE);
 }
 
 void BIDIReverseConvert(wxString* text)
 {
-	UErrorCode errorCode = U_ZERO_ERROR;
-
-	// Open a new UBiDiTransform.
-
-	UBiDiTransform* transform = ubiditransform_open(&errorCode);
-
-	// Run a transformation.
-	std::wstring wtext = text->ToStdWstring();
-
-	std::u16string text1(wtext.begin(), wtext.end());
-	size_t len = (text1.size() + 3) * 2;
-	UChar* text2 = (UChar*)malloc(len);
-	if (!text2) {
-		KaiLog(L"Cannot allocate bidi conversion text");
-		return;
-	}
-
-	ubiditransform_transform(transform, text1.data(), -1, text2, (len),
+	TransformBidiText(text,
 		UBIDI_LTR, UBIDI_VISUAL, UBIDI_RTL, UBIDI_LOGICAL,
-		UBIDI_MIRRORING_OFF, U_SHAPE_LETTERS_UNSHAPE, &errorCode);
-
-	ubiditransform_close(transform);
-	std::u16string result16(text2);
-	const wchar_t* result = reinterpret_cast<const wchar_t*>(result16.c_str());
-
-	(*text) = wxString(result);
-	free(text2);
+		U_SHAPE_LETTERS_UNSHAPE);
 }
 
 //put normal RTL text and get converted to LTR when text == nullptr or len = 0 function fail

--- a/Kainote/ColorPicker.cpp
+++ b/Kainote/ColorPicker.cpp
@@ -1247,7 +1247,6 @@ void ButtonColorPicker::OnClick(wxCommandEvent &event)
 	DialogColorPicker *dcp = DialogColorPicker::Get(this, ActualColor);
 	wxPoint mst = wxGetMousePosition();
 	wxSize siz = dcp->GetSize();
-	siz.x;
 	wxRect rc = wxGetClientDisplayRect();
 	mst.x -= (siz.x / 2);
 	mst.x = MID(rc.x, mst.x, rc.width - siz.x);
@@ -1525,10 +1524,9 @@ SimpleColorPicker::~SimpleColorPicker()
 bool SimpleColorPicker::PickColor(AssColor *returnColor)
 {
 	if (scpd->ShowModal() == wxID_OK){
-		if (!returnColor)
+		if (returnColor)
 			*returnColor = scpd->GetColor();
 		return true;
 	}
 	return false;
 }
-

--- a/Kainote/DialogueTextEditor.cpp
+++ b/Kainote/DialogueTextEditor.cpp
@@ -2497,7 +2497,7 @@ wxPoint TextEditor::PosFromCursor(wxPoint cur)
 		GraphicsContext* gc = GetGraphicsContext();
 		if (gc){
 			gc->SetFont(font, L"#000000");
-			double gcfw, gcfh;
+			double gcfw = 0.0, gcfh = 0.0;
 			gc->GetTextExtent(MText.SubString(wraps[cur.y], cur.x), &gcfw, &gcfh);
 			delete gc;
 			fw = gcfw + 0.5f;
@@ -2926,7 +2926,6 @@ EVT_SET_FOCUS(TextEditor::OnKillFocus)
 EVT_COMMAND_SCROLL(3333, TextEditor::OnScroll)
 EVT_MOUSE_CAPTURE_LOST(TextEditor::OnLostCapture)
 END_EVENT_TABLE()
-
 
 
 

--- a/Kainote/EditBox.cpp
+++ b/Kainote/EditBox.cpp
@@ -641,10 +641,11 @@ void EditBox::Send(unsigned char editionType, bool gotoNextLine, bool dummy, boo
 void EditBox::PutinNonass(const wxString &text, const wxString &tag)
 {
 	if (grid->subsFormat == TMP) return;
-	long from, to, whre;
+	long from, to;
 	size_t start = 0, len = 0;
 	bool match = false;
 	TextEdit->GetSelection(&from, &to);
+	long whre = from;
 	wxString txt = TextEdit->GetValue();
 	bool oneline = (grid->SelectionsSize() < 2);
 	if (oneline){//Changing only in editbox
@@ -694,7 +695,10 @@ void EditBox::PutinNonass(const wxString &text, const wxString &tag)
 					match = true;
 				}
 			}
-			if (!match){ txt.insert(wheres, L"{" + tag + L"}"); }
+			if (!match){
+				txt.insert(wheres, L"{" + tag + L"}");
+				whre = wheres + tag.length() + 2;
+			}
 
 		}
 
@@ -1610,7 +1614,7 @@ void EditBox::OnColorChange(ColorEvent& event)
 		wxString tag = (intColorNumber == 1) ? L"?c&(.*)&" : L"c&(.*)&";
 		Styles *style = grid->GetStyle(0, line->Style);
 
-		bool found = FindTag(colorNumber + tag, emptyString, 0, true);
+		FindTag(colorNumber + tag, emptyString, 0, true);
 		//check only colors, not aplha
 		if (actualColor.r != choosenColor.r || actualColor.g != choosenColor.g || 
 			actualColor.b != choosenColor.b){
@@ -1619,7 +1623,7 @@ void EditBox::OnColorChange(ColorEvent& event)
 				L"\\" + colorNumber + L"c" + actualColorstr + L"&", false);
 		}
 
-		if (found = FindTag(L"(" + colorNumber + L"a&|alpha.*)", emptyString, 0, true)){
+		if (FindTag(L"(" + colorNumber + L"a&|alpha.*)", emptyString, 0, true)){
 			GetTextResult(&colorString);
 			if (!colorString.StartsWith(colorNumber + L"a&")){
 				wxPoint pos = GetPositionInText();
@@ -2226,4 +2230,3 @@ bool EditBox::SetFont(const wxFont &font)
 	Layout();
 	return true;
 }
-

--- a/Kainote/FontCollector.cpp
+++ b/Kainote/FontCollector.cpp
@@ -33,6 +33,7 @@
 #include <wx/wfstream.h>
 #include <wx/dir.h>
 #include <wx/regex.h>
+#include <wx/utils.h>
 #include <ShlObj.h>
 
 wxDEFINE_EVENT(EVT_APPEND_MESSAGE, wxThreadEvent);
@@ -553,12 +554,14 @@ FontCollector::FontCollector(wxWindow *parent)
 	:zip(nullptr)
 	, fcd(nullptr)
 	, reloadFonts(false)
+	, fontObserverClient(parent)
 {
 	FontEnum.AddClient(parent, [this](){reloadFonts = true; });
 }
 
 FontCollector::~FontCollector()
 {
+	FontEnum.RemoveClient(fontObserverClient);
 	//test if it not crash nothing
 	if (fcd)
 		fcd->Destroy();
@@ -1062,6 +1065,8 @@ bool FontCollector::CheckPathAndGlyphs(int *found, int *notFound, int *notCopied
 	bool needInit = true;
 	bool copyFonts = !(operation & CHECK_FONTS);
 	HDC dc = ::CreateCompatibleDC(nullptr);
+	if (!dc)
+		return false;
 	auto it = foundFonts.begin();
 	wxString lastfn;
 	for (size_t k = 0; k < foundFonts.size(); k++){
@@ -1088,7 +1093,7 @@ bool FontCollector::CheckPathAndGlyphs(int *found, int *notFound, int *notCopied
 			//no goto cause font is not created yet
 		}
 		auto hfont = CreateFontIndirectW(&mlf);
-		SelectObject(dc, hfont);
+		HGDIOBJ oldFont = SelectObject(dc, hfont);
 		if (font->fakeNormal){
 			flc->AppendWarnings(wxString::Format(_("Czcionka \"%s\" nie ma stylu normalnego."), fn));
 		}
@@ -1179,6 +1184,9 @@ bool FontCollector::CheckPathAndGlyphs(int *found, int *notFound, int *notCopied
 						if (needInit) {
 							if (operation & COPY_FONTS && !MakeDirectory(operation & AS_ZIP)) {
 								*notFound = -1;
+								SelectObject(dc, oldFont);
+								DeleteObject(hfont);
+								::DeleteDC(dc);
 								return true;
 							}
 							needInit = false;
@@ -1222,7 +1230,7 @@ bool FontCollector::CheckPathAndGlyphs(int *found, int *notFound, int *notCopied
 		//rest fonts it's just bold/italic version not count it
 	done:
 
-		SelectObject(dc, nullptr);
+		SelectObject(dc, oldFont);
 		DeleteObject(hfont);
 	}
 	::DeleteDC(dc);
@@ -1231,38 +1239,41 @@ bool FontCollector::CheckPathAndGlyphs(int *found, int *notFound, int *notCopied
 
 void FontCollector::MuxVideoWithSubs()
 {
+	TabPanel* tab = Notebook::GetTab();
+	if (!tab)
+		return;
 
-
-	wxString command = L"\"--ui-language\" \"pl\" \"--output\" \"" + Notebook::GetTab()->VideoPath.BeforeLast(L'.') + L" (1).mkv\" " +
-		L"\"--language\" \"0:und\" \"--language\" \"1:und\" ( \""\
-		+ Notebook::GetTab()->VideoPath +
-		L"\" ) \"--language\" \"0:und\" ( \"" + Notebook::GetTab()->SubsPath +
-		L"\" ) ";// odtąd trzeba dodać czcionki
+	std::vector<wxString> arguments{
+		muxerpath,
+		L"--ui-language", L"pl",
+		L"--output", tab->VideoPath.BeforeLast(L'.') + L" (1).mkv",
+		L"--language", L"0:und",
+		L"--language", L"1:und",
+		L"(", tab->VideoPath, L")",
+		L"--language", L"0:und",
+		L"(", tab->SubsPath, L")"
+	};
 	for (size_t i = 0; i < fontnames.size(); i++){
-		wxString ext = fontnames[i].AfterLast(L'.').Lower();
-		
-		command << L"\"--attachment-name\" \"";
 		wxString name = KaiPathName(fontnames[i]);
-		command << name << L"\" ";
-		command << L"\"--attachment-mime-type\" ";
-		//if(ext=="ttf" || ext=="ttc"){
-		command << L"\"application/x-truetype-font\" ";//}
-		//else if(ext=="otf"){command << L"\"application/font-woff\" ";}
-		//else otf itp
-		command << L"\"--attach-file\" \"";
-		command << KaiPathJoin(fcd->copypath, name) << L"\" ";
+		arguments.push_back(L"--attachment-name");
+		arguments.push_back(name);
+		arguments.push_back(L"--attachment-mime-type");
+		arguments.push_back(L"application/x-truetype-font");
+		arguments.push_back(L"--attach-file");
+		arguments.push_back(KaiPathJoin(fcd->copypath, name));
 	}
-	command.Replace("\\", "/");
-	command << L"\"--track-order\" \"0:0,0:1,1:0\"";
-	wxString fullcommand = L"\"" + muxerpath + L"\"" + command;
+	arguments.push_back(L"--track-order");
+	arguments.push_back(L"0:0,0:1,1:0");
 
-	STARTUPINFO si = { sizeof(si) };
-	PROCESS_INFORMATION pi;
-	if (!CreateProcessW(nullptr, (LPWSTR)fullcommand.wc_str(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)){
+	std::vector<const wchar_t*> argv;
+	argv.reserve(arguments.size() + 1);
+	for (const auto& argument : arguments)
+		argv.push_back(argument.wc_str());
+	argv.push_back(nullptr);
+
+	if (wxExecute(argv.data(), wxEXEC_ASYNC) == 0){
 		KaiLog(_("Nie można stworzyć procesu, muxowanie przerwane"));
 	}
-
-
 }
 
 void FontCollector::ShowDialog(wxWindow *parent)
@@ -1325,4 +1336,3 @@ wxThread::ExitCode FontCollectorThread::Entry()
 	}
 	return 0;
 }
-

--- a/Kainote/FontCollector.h
+++ b/Kainote/FontCollector.h
@@ -200,6 +200,7 @@ private:
 	int operation;
 	bool reloadFonts;
 	bool hasExternalFolder = false;
+	const wxWindow* fontObserverClient = nullptr;
 };
 
 class FontCollectorThread : public wxThread

--- a/Kainote/FontEnumerator.cpp
+++ b/Kainote/FontEnumerator.cpp
@@ -18,17 +18,31 @@
 #include "Notebook.h"
 #include "ProgressDialog.h"
 
+#include <wx/app.h>
 #include <wx/arrstr.h>
 #include <wx/filefn.h>
+#include <condition_variable>
+#include <mutex>
 #include <unicode/utf16.h>
 //#include <windows.h>
 #include <Usp10.h>
 
 #include <ShlObj.h>
 
-	
+namespace {
+constexpr unsigned int REFRESH_FONT_CLIENTS = 1u;
+constexpr unsigned int REFRESH_VIDEO_SUBTITLES = 2u;
+}
 
-
+struct FontEnumerator::UiRefreshState
+{
+	std::mutex mutex;
+	std::condition_variable callbackFinished;
+	FontEnumerator* owner = nullptr;
+	unsigned int pendingRequests = 0;
+	bool callbackQueued = false;
+	bool callbackRunning = false;
+};
 
 FontEnumerator::FontEnumerator()
 {
@@ -36,29 +50,18 @@ FontEnumerator::FontEnumerator()
 	FontsTmp = new wxArrayString();
 	FilteredFonts = nullptr;
 	FilteredFontsTmp = nullptr;
+	uiRefreshState = std::make_shared<UiRefreshState>();
+	uiRefreshState->owner = this;
 }
 
 FontEnumerator::~FontEnumerator()
 {
-	for (auto& event : eventKillSelf) {
-		if (event)
-			SetEvent(event);
-	}
-	if (loadFontsThread) {
-		WaitForSingleObject(loadFontsThread, 2000);
-		CloseHandle(loadFontsThread);
-		loadFontsThread = nullptr;
-	}
-	for (auto& event : eventKillSelf) {
-		if (event)
-			SetEvent(event);
-	}
-	for (auto& thread : checkFontsThread) {
-		if (thread) {
-			WaitForSingleObject(thread, 2000);
-			CloseHandle(thread);
-			thread = nullptr;
-		}
+	StopEnumeration();
+	if (uiRefreshState) {
+		std::unique_lock<std::mutex> lock(uiRefreshState->mutex);
+		uiRefreshState->callbackFinished.wait(lock, [this] {
+			return !uiRefreshState->callbackRunning;
+		});
 	}
 	for (auto& event : eventKillSelf) {
 		if (event) {
@@ -74,22 +77,67 @@ FontEnumerator::~FontEnumerator()
 
 void FontEnumerator::StartListening()
 {
+	if (shuttingDown.load())
+		return;
 	//Here check Windows Version and save it
 	//without manifest I get only version 6.2
 	//it means that user have Windows 8 without SP
-	for (int i = 0; i < 2; i++){
+#ifdef _WIN32
+	const int watcherCount = 2;
+	for (int i = 0; i < watcherCount; i++){
 		if (!eventKillSelf[i])
 			eventKillSelf[i] = CreateEvent(0, FALSE, FALSE, 0);
 		int * threadNum = new int(i);
-		checkFontsThread[i] = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)CheckFontsProc, threadNum, 0, 0);
+		checkFontsThread[i] = CreateThread(nullptr, 0, CheckFontsProc, threadNum, 0, 0);
 		if(checkFontsThread[i])
 			SetThreadPriority(checkFontsThread[i], THREAD_PRIORITY_LOWEST);
 	}
+#else
+	// Add the external root after its startup load finishes.
+	RestartLinuxFontWatcher(wxString());
+#endif
 }
+
+#ifndef _WIN32
+void FontEnumerator::RestartLinuxFontWatcher(const wxString& externalFontsPath)
+{
+	if (checkFontsThread[0]) {
+		if (eventKillSelf[0])
+			SetEvent(eventKillSelf[0]);
+		WaitForSingleObject(checkFontsThread[0], INFINITE);
+		CloseHandle(checkFontsThread[0]);
+		checkFontsThread[0] = nullptr;
+	}
+	if (shuttingDown.load())
+		return;
+
+	linuxExternalFontsPath = externalFontsPath;
+	if (!eventKillSelf[0])
+		eventKillSelf[0] = CreateEvent(0, FALSE, FALSE, 0);
+	else
+		ResetEvent(eventKillSelf[0]);
+	if (!eventKillSelf[0])
+		return;
+
+	int* threadNum = new int(0);
+	checkFontsThread[0] = CreateThread(
+		nullptr, 0, CheckFontsProc, threadNum, 0, 0);
+	if (!checkFontsThread[0]) {
+		delete threadNum;
+		return;
+	}
+	SetThreadPriority(checkFontsThread[0], THREAD_PRIORITY_LOWEST);
+}
+#endif
 
 void FontEnumerator::EnumerateFonts(bool reenumerate)
 {
 	wxMutexLocker lock(enumerateMutex);
+	EnumerateFontsLocked(reenumerate);
+}
+
+void FontEnumerator::EnumerateFontsLocked(bool reenumerate)
+{
 	FontsTmp->Clear();
 	if(FilteredFontsTmp){FilteredFontsTmp->Clear();}
 	LOGFONT lf;
@@ -97,7 +145,7 @@ void FontEnumerator::EnumerateFonts(bool reenumerate)
 	wxStrlcpy(lf.lfFaceName, L"\0", WXSIZEOF(lf.lfFaceName));
 	lf.lfPitchAndFamily = 0;
 	hdc = ::GetDC(nullptr);
-	EnumFontFamiliesEx(hdc, &lf, (FONTENUMPROC)FontEnumeratorProc,
+	EnumFontFamiliesEx(hdc, &lf, FontEnumeratorProc,
 		(LPARAM)this, 0 /* reserved */);
 	FontsTmp->Sort([](const wxString &i, const wxString &j){return i.CmpNoCase(j);});
 	wxArrayString *tmp = FontsTmp;
@@ -118,7 +166,7 @@ wxArrayString *FontEnumerator::GetFonts(const wxWindow *client, std::function<vo
 {
 	wxMutexLocker lock(enumerateMutex);
 	if(Fonts->size() < 1){
-		EnumerateFonts(false);
+		EnumerateFontsLocked(false);
 	}
 	if(client){
 		observers[client] = func;
@@ -133,7 +181,7 @@ wxArrayString *FontEnumerator::GetFilteredFonts(const wxWindow *client, std::fun
 	if(!FilteredFonts){
 		FilteredFonts = new wxArrayString();
 		FilteredFontsTmp = new wxArrayString();
-		EnumerateFonts(false);
+		EnumerateFontsLocked(false);
 	}
 	if(client && !(observers.find(client) != observers.end())){observers[client] = func;}
 	return FilteredFonts;
@@ -175,12 +223,87 @@ void FontEnumerator::RefreshClientsFonts()
 	}
 }
 
+void FontEnumerator::RequestUiRefresh(bool refreshVideo)
+{
+	const std::shared_ptr<UiRefreshState> state = uiRefreshState;
+	if (!state)
+		return;
 
-int __stdcall FontEnumerator::FontEnumeratorProc(LPLOGFONT lplf, TEXTMETRIC* lptm,
-	unsigned int dwStyle, long* lParam)
+	std::lock_guard<std::mutex> lock(state->mutex);
+	if (state->owner != this || shuttingDown.load())
+		return;
+
+	state->pendingRequests |= REFRESH_FONT_CLIENTS;
+	if (refreshVideo)
+		state->pendingRequests |= REFRESH_VIDEO_SUBTITLES;
+	if (state->callbackQueued)
+		return;
+
+	wxApp* app = wxTheApp;
+	if (!app) {
+		state->pendingRequests = 0;
+		return;
+	}
+
+	state->callbackQueued = true;
+	app->CallAfter([state]() {
+		for (;;) {
+			FontEnumerator* owner = nullptr;
+			unsigned int requests = 0;
+			{
+				std::lock_guard<std::mutex> stateLock(state->mutex);
+				owner = state->owner;
+				if (!owner) {
+					state->pendingRequests = 0;
+					state->callbackQueued = false;
+					state->callbackRunning = false;
+					state->callbackFinished.notify_all();
+					return;
+				}
+				requests = state->pendingRequests;
+				state->pendingRequests = 0;
+				state->callbackRunning = true;
+			}
+
+			// Controls retain raw array pointers; rebuild them on the UI thread.
+			if (requests & REFRESH_FONT_CLIENTS) {
+				owner->EnumerateFonts(true);
+				owner->RefreshClientsFonts();
+			}
+
+			bool refreshVideo = false;
+			{
+				std::lock_guard<std::mutex> stateLock(state->mutex);
+				refreshVideo = state->owner == owner &&
+					(requests & REFRESH_VIDEO_SUBTITLES) != 0;
+			}
+			if (refreshVideo && Notebook::GetTabs())
+				Notebook::RefreshVideo(true);
+
+			{
+				std::lock_guard<std::mutex> stateLock(state->mutex);
+				state->callbackRunning = false;
+				state->callbackFinished.notify_all();
+				if (!state->owner) {
+					state->pendingRequests = 0;
+					state->callbackQueued = false;
+					return;
+				}
+				if (state->pendingRequests == 0) {
+					state->callbackQueued = false;
+					return;
+				}
+			}
+		}
+	});
+}
+
+
+int __stdcall FontEnumerator::FontEnumeratorProc(const LOGFONT* lplf,
+	const TEXTMETRIC* lptm, DWORD dwStyle, LPARAM lParam)
 
 {
-	FontEnumerator *Enum = (FontEnumerator*)lParam;
+	FontEnumerator *Enum = reinterpret_cast<FontEnumerator*>(lParam);
 	if (lplf->lfOutPrecision == 1){
 		// remove some .fon fonts but not all, modern, roman, script still there
 		// these fonts not working with Vobsub nor D2D
@@ -204,9 +327,9 @@ int __stdcall FontEnumerator::FontEnumeratorProc(LPLOGFONT lplf, TEXTMETRIC* lpt
 }
 
 
-DWORD FontEnumerator::CheckFontsProc(int *threadNum)
+DWORD WINAPI FontEnumerator::CheckFontsProc(void* threadNumber)
 {
-	
+	int* threadNum = static_cast<int*>(threadNumber);
 	if (!FontEnum.eventKillSelf[*threadNum])
 		FontEnum.eventKillSelf[*threadNum] = CreateEvent(0, FALSE, FALSE, 0);
 	HANDLE eventKillSelf = FontEnum.eventKillSelf[*threadNum];
@@ -215,6 +338,20 @@ DWORD FontEnumerator::CheckFontsProc(int *threadNum)
 		return 0;
 	}
 	wxString fontrealpath;
+	HANDLE hDir = nullptr;
+#ifndef _WIN32
+	if (*threadNum != 0) {
+		delete threadNum;
+		return 0;
+	}
+	fontrealpath = FontEnum.linuxExternalFontsPath;
+	auto watchedDirectories = kainote_linux_font_directories();
+	// Poll missing roots instead of watching a broad ancestor.
+	if (!fontrealpath.empty() && wxDirExists(fontrealpath))
+		watchedDirectories.push_back(fontrealpath.ToStdWstring());
+	hDir = kainote_find_first_change_notifications(
+		watchedDirectories, TRUE, FILE_NOTIFY_CHANGE_FILE_NAME);
+#else
 	if (*threadNum == 0)
 		fontrealpath = wxGetOSDirectory() + L"\\fonts\\";
 	else if(*threadNum == 1) {
@@ -232,8 +369,8 @@ DWORD FontEnumerator::CheckFontsProc(int *threadNum)
 		fontrealpath = Options.GetString(EXTERNAL_FONTS_DIRECTORY);
 	}
 
-	HANDLE hDir = nullptr;
 	hDir = FindFirstChangeNotification( fontrealpath.wc_str(), TRUE, FILE_NOTIFY_CHANGE_FILE_NAME);// | FILE_NOTIFY_CHANGE_LAST_WRITE
+#endif
 
 	if (hDir == INVALID_HANDLE_VALUE){ 
 #ifdef _WIN32
@@ -252,23 +389,74 @@ DWORD FontEnumerator::CheckFontsProc(int *threadNum)
 		hDir,
 		eventKillSelf
 	};
+#ifndef _WIN32
+	bool retryMissingExternalDirectory =
+		!fontrealpath.empty() && !wxDirExists(fontrealpath);
+#endif
 
 	while(1){
-		DWORD wait_result = WaitForMultipleObjects(sizeof(events_to_wait)/sizeof(HANDLE), events_to_wait, FALSE, INFINITE);
+		DWORD waitTimeout = INFINITE;
+#ifndef _WIN32
+		if (retryMissingExternalDirectory)
+			waitTimeout = 1000;
+#endif
+		DWORD wait_result = WaitForMultipleObjects(
+			sizeof(events_to_wait) / sizeof(HANDLE), events_to_wait, FALSE, waitTimeout);
+#ifndef _WIN32
+		if (wait_result == WAIT_TIMEOUT) {
+			if (!fontrealpath.empty() && wxDirExists(fontrealpath)) {
+				auto watchedDirectories = kainote_linux_font_directories();
+				watchedDirectories.push_back(fontrealpath.ToStdWstring());
+				HANDLE replacement = kainote_find_first_change_notifications(
+					watchedDirectories, TRUE, FILE_NOTIFY_CHANGE_FILE_NAME);
+				if (replacement != INVALID_HANDLE_VALUE) {
+					FindCloseChangeNotification(hDir);
+					hDir = replacement;
+					events_to_wait[0] = hDir;
+					retryMissingExternalDirectory = false;
+					// No later event is guaranteed, so snapshot immediately.
+					ProgressSinkSilent* progr = new ProgressSinkSilent(
+						_("Ładowanie czcionek zewnętrznych"));
+					FontEnum.progress = progr;
+					FontEnum.RemoveExternalFontsFromProcess(fontrealpath);
+					FontEnum.LoadExternalFontsToProcess(fontrealpath);
+					progr->EndModal();
+					delete progr;
+					FontEnum.progress = nullptr;
+					FontEnum.RequestUiRefresh(true);
+				}
+			}
+			continue;
+		}
+#endif
 		if(wait_result == WAIT_OBJECT_0 + 0){
 			Sleep(1000);
-			if (*threadNum == 2) {
+			if (WaitForSingleObject(eventKillSelf, 0) == WAIT_OBJECT_0)
+				break;
+			bool reloadExternalFonts = false;
+#ifdef _WIN32
+			reloadExternalFonts = *threadNum == 2 && !fontrealpath.empty();
+#else
+			reloadExternalFonts = *threadNum == 0 && !fontrealpath.empty();
+#endif
+			if (reloadExternalFonts) {
 				ProgressSinkSilent* progr = new ProgressSinkSilent(_("Ładowanie czcionek zewnętrznych"));
 				FontEnum.progress = progr;
 				FontEnum.RemoveExternalFontsFromProcess(fontrealpath);
-				FontEnum.LoadExternalFontsToProcess(fontrealpath);
-				FontEnum.progress->EndModal();
+				if (wxDirExists(fontrealpath))
+					FontEnum.LoadExternalFontsToProcess(fontrealpath);
+				progr->EndModal();
+				delete progr;
+				FontEnum.progress = nullptr;
 			}
-			FontEnum.EnumerateFonts(true);
-			FontEnum.RefreshClientsFonts();
-			Notebook::RefreshVideo(true);
+			FontEnum.RequestUiRefresh(true);
+#ifndef _WIN32
+			retryMissingExternalDirectory =
+				!fontrealpath.empty() && !wxDirExists(fontrealpath);
+#endif
 			if(FindNextChangeNotification( hDir ) == 0){
 				KaiLog(_("Nie można stworzyć następnego uchwytu notyfikacji zmian folderu czcionek."));
+				FindCloseChangeNotification(hDir);
 				delete threadNum;
 				return 0;
 			}
@@ -280,30 +468,31 @@ DWORD FontEnumerator::CheckFontsProc(int *threadNum)
 	return FindCloseChangeNotification( hDir );
 }
 
-DWORD FontEnumerator::LoadExternalFontsProc(void* path)
+DWORD WINAPI FontEnumerator::LoadExternalFontsProc(void* path)
 {
-	wxString* fontpath = (wxString*)path;
-	FontEnum.LoadExternalFontsToProcess(*fontpath);
-	delete fontpath;
+	wxString* fontpathArgument = (wxString*)path;
+	wxString fontpath = *fontpathArgument;
+	delete fontpathArgument;
+	FontEnum.LoadExternalFontsToProcess(fontpath);
 	if (!FontEnum.progress)
 		return 0;
 
 	FontEnum.progress->EndModal();
 	delete FontEnum.progress;
 	FontEnum.progress = nullptr;
-	if (FontEnum.Fonts->size()) {
-		FontEnum.EnumerateFonts(true);
-		FontEnum.RefreshClientsFonts();
-	}
+	FontEnum.RequestUiRefresh(false);
 	//Notebook::RefreshVideo(true);
 
-	//Listening of external fonts folder
+#ifndef _WIN32
+	FontEnum.RestartLinuxFontWatcher(fontpath);
+#else
 	int* threadNum = new int(2);
 	if (!FontEnum.eventKillSelf[2])
 		FontEnum.eventKillSelf[2] = CreateEvent(0, FALSE, FALSE, 0);
-	FontEnum.checkFontsThread[2] = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)CheckFontsProc, threadNum, 0, 0);
+	FontEnum.checkFontsThread[2] = CreateThread(nullptr, 0, CheckFontsProc, threadNum, 0, 0);
 	if (FontEnum.checkFontsThread[2])
 		SetThreadPriority(FontEnum.checkFontsThread[2], THREAD_PRIORITY_LOWEST);
+#endif
 
 	return 0;
 }
@@ -362,6 +551,15 @@ bool FontEnumerator::CheckGlyphsExists(HDC dc, const wxString &textForCheck, wxS
 
 void FontEnumerator::ReloadExternalFontsToProcess(const wxString& newFontsPath, wxWindow* parent)
 {
+	// Serialize settings reload with the startup loader.
+	if (loadFontsThread) {
+		WaitForSingleObject(loadFontsThread, INFINITE);
+		CloseHandle(loadFontsThread);
+		loadFontsThread = nullptr;
+	}
+#ifndef _WIN32
+	RestartLinuxFontWatcher(wxString());
+#endif
 	if (progress) {
 		Sink* progresscopy = progress;
 		progress = nullptr;
@@ -389,6 +587,10 @@ void FontEnumerator::ReloadExternalFontsToProcess(const wxString& newFontsPath, 
 	RefreshClientsFonts();
 	delete progress;
 	progress = nullptr;
+#ifndef _WIN32
+	// Keep polling until a missing external root appears.
+	RestartLinuxFontWatcher(newFontsPath);
+#endif
 }
 
 bool FontEnumerator::LoadExternalFontsToProcess(const wxString& fontsPath)
@@ -403,30 +605,30 @@ bool FontEnumerator::LoadExternalFontsToProcess(const wxString& fontsPath)
 		return false;
 	}
 	int fontAdded = 0;
-	wxArrayString ExternalFonts;
-	while (1) {
-		int result = FindNextFileW(h, &data);
-		if (result == ERROR_NO_MORE_FILES || result == 0) { break; }
-		else if (data.nFileSizeLow == 0) { continue; }
+	wxArrayString discoveredFonts;
+	do {
 		wxString file = wxString(data.cFileName);
-		wxString ext = file.AfterLast(L'.');
+		if (file == L"." || file == L".." || data.nFileSizeLow == 0) { continue; }
+		wxString ext = file.AfterLast(L'.').Lower();
 		if (ext == L"ttf" || ext == L"otf" || ext == L"ttc" || ext == L"pfb"/* || ext == L"pfm"*/) {
-			ExternalFonts.Add(file);
+			discoveredFonts.Add(file);
 		}
-	}
+	} while (FindNextFileW(h, &data));
 	FindClose(h);
-	size_t size = ExternalFonts.Count();
+	size_t size = discoveredFonts.Count();
 	for (size_t i = 0; i < size; i++) {
-		wxString pathAndFile = fontsPath + ExternalFonts[i];
+		const wxString& file = discoveredFonts[i];
+		if (ExternalFonts.Index(file) != wxNOT_FOUND)
+			continue;
+		wxString pathAndFile = fontsPath + file;
 		int addResult = AddFontResourceExW(pathAndFile.wc_str(), FR_PRIVATE, nullptr);
 		if (addResult == 0)
-			KaiLogSilent(L"Cannot add external font file " + ExternalFonts[i] + L".\n");
+			KaiLogSilent(L"Cannot add external font file " + file + L".\n");
 		else {
 			fontAdded += addResult;
+			ExternalFonts.Add(file);
 			if (progress)
-				progress->Progress(( i / (float)size) * 100);
-			else
-				break;
+				progress->Progress(((i + 1) / (float)size) * 100);
 		}
 	}
 	//KaiLogSilent(L"Loaded external font files " + std::to_wstring(fontAdded) + L".\n");
@@ -438,43 +640,79 @@ bool FontEnumerator::LoadExternalFontsToProcess(const wxString& fontsPath)
 
 void FontEnumerator::LoadExternalFontsToProcessFromThread(const wxString& fontsPath)
 {
-	ProgressSinkSilent* progr = new ProgressSinkSilent(_("Ładowanie czcionek zewnętrznych"));
-	progress = progr;
-	//set worker thread
-	wxString* ppath = new wxString(fontsPath);
+	if (shuttingDown.load())
+		return;
 	if (loadFontsThread) {
 		WaitForSingleObject(loadFontsThread, INFINITE);
 		CloseHandle(loadFontsThread);
 		loadFontsThread = nullptr;
 	}
-	loadFontsThread = CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)LoadExternalFontsProc, ppath, 0, 0);
-	
+	if (shuttingDown.load())
+		return;
+	ProgressSinkSilent* progr = new ProgressSinkSilent(_("Ładowanie czcionek zewnętrznych"));
+	progress = progr;
+	wxString* ppath = new wxString(fontsPath);
+	loadFontsThread = CreateThread(nullptr, 0, LoadExternalFontsProc, ppath, 0, 0);
+	if (!loadFontsThread) {
+		delete ppath;
+		if (progress == progr)
+			progress = nullptr;
+		delete progr;
+	}
 }
 
 void FontEnumerator::RemoveExternalFontsFromProcess(const wxString& fontsPath)
 {
 	int fontRemoved = 0;
 	size_t size = ExternalFonts.Count();
+	wxArrayString remainingFonts;
 	for (size_t i = 0; i < size; i++) {
 		wxString pathAndFile = fontsPath + ExternalFonts[i];
 		if (RemoveFontResourceExW(pathAndFile.wc_str(), FR_PRIVATE, nullptr)) {
 			fontRemoved++;
 			if (progress)
-				progress->Progress((i / (float)size) * 100);
-			else
-				break;
+				progress->Progress(((i + 1) / (float)size) * 100);
 		}
+		else
+			remainingFonts.Add(ExternalFonts[i]);
 	}
 		
 	//KaiLogSilent(L"Removed " + std::to_wstring(fontRemoved) + L" fonts.\n");
-	hasExternalFontsLoaded = false;
-	ExternalFonts.clear();
+	ExternalFonts = remainingFonts;
+	hasExternalFontsLoaded = !ExternalFonts.empty();
 
 	return;
 }
 
 void FontEnumerator::StopEnumeration()
 {
+	shuttingDown.store(true);
+	if (uiRefreshState) {
+		std::lock_guard<std::mutex> lock(uiRefreshState->mutex);
+		uiRefreshState->owner = nullptr;
+		uiRefreshState->pendingRequests = 0;
+	}
+	for (auto& event : eventKillSelf) {
+		if (event)
+			SetEvent(event);
+	}
+	// Prevent the loader from restarting the watcher during teardown.
+	if (loadFontsThread) {
+		WaitForSingleObject(loadFontsThread, INFINITE);
+		CloseHandle(loadFontsThread);
+		loadFontsThread = nullptr;
+	}
+	for (auto& event : eventKillSelf) {
+		if (event)
+			SetEvent(event);
+	}
+	for (auto& thread : checkFontsThread) {
+		if (thread) {
+			WaitForSingleObject(thread, INFINITE);
+			CloseHandle(thread);
+			thread = nullptr;
+		}
+	}
 	Sink* tmpProgress = progress;
 	progress = nullptr;
 	delete tmpProgress;

--- a/Kainote/FontEnumerator.h
+++ b/Kainote/FontEnumerator.h
@@ -23,6 +23,8 @@
 #include <map>
 #include <vector>
 #include <functional>
+#include <atomic>
+#include <memory>
 
 #include <windows.h>
 //#include <windef.h>
@@ -60,11 +62,17 @@ public:
 	HDC hdc;
 	wxString filter;
 private:
+	struct UiRefreshState;
+	void EnumerateFontsLocked(bool reenumerate);
 	void RefreshClientsFonts();
-	static int __stdcall FontEnumeratorProc(LPLOGFONT lplf, TEXTMETRIC *lptm,
-		unsigned int WXUNUSED(dwStyle), long* lParam);
-	static DWORD CheckFontsProc(int *threadNum);
-	static DWORD LoadExternalFontsProc(void *path);
+	void RequestUiRefresh(bool refreshVideo);
+#ifndef _WIN32
+	void RestartLinuxFontWatcher(const wxString& externalFontsPath);
+#endif
+	static int __stdcall FontEnumeratorProc(const LOGFONT* lplf,
+		const TEXTMETRIC* lptm, DWORD WXUNUSED(dwStyle), LPARAM lParam);
+	static DWORD WINAPI CheckFontsProc(void* threadNumber);
+	static DWORD WINAPI LoadExternalFontsProc(void* path);
 	
 	
 	std::map<const wxWindow*, std::function<void()>> observers;
@@ -73,9 +81,14 @@ private:
 	HANDLE checkFontsThread[3] = { nullptr, nullptr, nullptr };
 	HANDLE loadFontsThread = nullptr;
 	wxMutex enumerateMutex;
+	std::shared_ptr<UiRefreshState> uiRefreshState;
+	std::atomic_bool shuttingDown{ false };
 	bool hasExternalFontsLoaded = false;
 	Sink* progress = nullptr;
+#ifndef _WIN32
+	// Updated only while the watcher is stopped.
+	wxString linuxExternalFontsPath;
+#endif
 };
 
 extern FontEnumerator FontEnum;
-

--- a/Kainote/GFFT/GFFT.cpp
+++ b/Kainote/GFFT/GFFT.cpp
@@ -157,6 +157,7 @@ public:
 template<typename T>
 class AbstractFFT {
 public:
+	virtual ~AbstractFFT() = default;
 	virtual void fft(T*) = 0;
 };
 class EmptyFFT { };
@@ -243,9 +244,15 @@ void FFT::Set(Provider *_prov){
 	Loki::Factory<AbstractFFT<float>, unsigned int> gfft_factory;
 	FactoryInit<GFFTList<GFFT, doublelen, doublelen + 20, float>::Result>::apply(gfft_factory);
 
+	delete gfft;
+	gfft = nullptr;
+	delete[] output;
+	output = nullptr;
+	delete[] input;
+	input = nullptr;
+	inputSize = 0;
 	gfft = gfft_factory.CreateObject(doublelen);
 	prov = _prov;
-	input = nullptr;
 	output = new float[doublelen * 2];
 }
 
@@ -282,4 +289,3 @@ void FFT::Transform(long long whre){
 float FFT::Get(int i){
 	return sqrt(output[i] * output[i] + output[i + 1] * output[i + 1]);
 }
-

--- a/Kainote/GFFT/GFFT.h
+++ b/Kainote/GFFT/GFFT.h
@@ -26,17 +26,17 @@ const unsigned long doublelen = line_length * 2;
 class FFT
 {
 public:
-	FFT(){};
+	FFT() = default;
 	~FFT();
 	void Set(Provider *_prov);
 	void Transform(long long whre);
 	float Get(int i);
 	void SetAudio(long long from, long long to);
-	float * output;
+	float * output = nullptr;
 private:
-	Provider *prov;
-	short * input;
-	AbstractFFT<float>* gfft;
+	Provider *prov = nullptr;
+	short * input = nullptr;
+	AbstractFFT<float>* gfft = nullptr;
 	long long inputSize = 0;
 	long long from = 0;
 	//size_t lastend = 0;

--- a/Kainote/KaiDialog.cpp
+++ b/Kainote/KaiDialog.cpp
@@ -378,6 +378,8 @@ void KaiDialog::SetNextControl(bool next)
 					}
 				}
 			}
+			if (!nextWindow)
+				break;
 			nextWindow = next ? nextWindow->GetNext() : nextWindow->GetPrevious();
 		}
 	}

--- a/Kainote/KaiListCtrl.cpp
+++ b/Kainote/KaiListCtrl.cpp
@@ -701,7 +701,11 @@ void KaiListCtrl::OnMouseEvent(wxMouseEvent &evt)
 		size_t maxVisible = ((h - headerHeight) / lineHeight) + 1;
 		size_t visibleSize = GetVisibleSize();
 		if (scPosV<0){ scPosV = 0; }
-		else if ((size_t)scPosV > visibleSize + 1 - maxVisible){ scPosV = visibleSize + 1 - maxVisible; }
+		else {
+			size_t maxScroll = visibleSize + 1 > maxVisible ? visibleSize + 1 - maxVisible : 0;
+			if ((size_t)scPosV > maxScroll)
+				scPosV = static_cast<int>(maxScroll);
+		}
 		Refresh(false);
 		return;
 	}
@@ -802,6 +806,9 @@ void KaiListCtrl::OnMouseEvent(wxMouseEvent &evt)
 					filteredList[elemYID] = newRow;
 					PushHistory();
 					Refresh(false);
+				}
+				else {
+					delete newRow;
 				}
 				copy = nullptr;
 			}

--- a/Kainote/KaiPanel.cpp
+++ b/Kainote/KaiPanel.cpp
@@ -17,15 +17,33 @@
 #include "ListControls.h"
 #include "KaiRadioButton.h"
 
+#include <vector>
+
 void KaiContainer::OnNavigation(wxNavigationKeyEvent& evt)
 {
+	if (!container) {
+		evt.Skip();
+		return;
+	}
 	bool next = evt.GetDirection();
 	wxWindow* focused = container->FindFocus();
+	if (!focused) {
+		evt.Skip();
+		return;
+	}
 	wxWindow* focusedParent = focused->GetParent();
+	if (!focusedParent) {
+		evt.Skip();
+		return;
+	}
 	bool nextWindowWasNULL = false;
 	if (focusedParent->IsKindOf(CLASSINFO(KaiChoice))) {
 		focused = focusedParent;
 		focusedParent = focusedParent->GetParent();
+		if (!focusedParent) {
+			evt.Skip();
+			return;
+		}
 	}
 
 	wxWindowList& list = focusedParent->GetChildren();
@@ -40,7 +58,10 @@ void KaiContainer::OnNavigation(wxNavigationKeyEvent& evt)
 				nextWindowWasNULL = true;
 				wxWindow* fparent = focusedParent;
 				while (fparent) {
-					wxWindowList& list1 = fparent->GetParent()->GetChildren();
+					wxWindow* parent = fparent->GetParent();
+					if (!parent)
+						break;
+					wxWindowList& list1 = parent->GetChildren();
 					//if panel is empty then just continue
 					//don't give it focus
 					if (!list1.GetCount()) {
@@ -73,7 +94,8 @@ void KaiContainer::OnNavigation(wxNavigationKeyEvent& evt)
 							win = FindCheckedRadiobutton(next, &nextWindow, focused);
 							if (!win) {
 								//get next window before continue
-								nextWindow = next ? nextWindow->GetNext() : nextWindow->GetPrevious();
+								if (nextWindow)
+									nextWindow = next ? nextWindow->GetNext() : nextWindow->GetPrevious();
 								continue;
 							}
 						}
@@ -97,6 +119,8 @@ void KaiContainer::OnNavigation(wxNavigationKeyEvent& evt)
 					}
 				}
 			}
+			if (!nextWindow)
+				break;
 			nextWindow = next ? nextWindow->GetNext() : nextWindow->GetPrevious();
 		}
 	}
@@ -170,28 +194,34 @@ wxWindow* KaiContainer::FindCheckedRadiobutton(bool next, wxWindowListNode** lis
 
 void KaiContainer::OnSetFocus(wxFocusEvent& evt)
 {
-	wxWindow* thiswindow = container;
-	while (thiswindow) {
-		wxWindowList& list = thiswindow->GetChildren();
+	if (!container) {
+		evt.Skip();
+		return;
+	}
+
+	std::vector<wxWindow*> pending{ container };
+	while (!pending.empty()) {
+		wxWindow* current = pending.back();
+		pending.pop_back();
+		wxWindowList& list = current->GetChildren();
 		wxWindowListNode* node = list.GetFirst();
 		wxWindow* win = nullptr;
 		FindFocusable(true, &node, &win);
 		if (win) {
 			win->SetFocus();
-			break;
+			return;
 		}
-		wxWindowListNode* firstnode = list.GetFirst();
-		while (firstnode) {
-			wxObject* data = firstnode->GetData();
+
+		for (wxWindowListNode* childNode = list.GetLast(); childNode;
+			childNode = childNode->GetPrevious()) {
+			wxObject* data = childNode->GetData();
 			if (data) {
-				wxWindow* win1 = wxDynamicCast(data, wxWindow);
-				if (win1) {
-					wxWindowList& list1 = win1->GetChildren();
-					if (list1.GetCount()) {
-						thiswindow = win1;
-					}
-				}
+				wxWindow* child = wxDynamicCast(data, wxWindow);
+				if (child && child->GetChildren().GetCount())
+					pending.push_back(child);
 			}
 		}
 	}
+
+	evt.Skip();
 }

--- a/Kainote/KainoteFrame.cpp
+++ b/Kainote/KainoteFrame.cpp
@@ -822,7 +822,7 @@ void KainoteFrame::OnMenuSelected(wxCommandEvent& event)
 		}
 	}
 	else if (id == GLOBAL_OPEN_SPELLCHECKER){
-		SpellCheckerDialog *SCD = new SpellCheckerDialog(this);
+		new SpellCheckerDialog(this);
 	}
 	else if (id == GLOBAL_HIDE_TAGS){
 		tab->grid->HideOverrideTags();
@@ -956,6 +956,7 @@ void KainoteFrame::OnMenuSelected(wxCommandEvent& event)
 	}
 	else if (id == GLOBAL_LOAD_LAST_SESSION_ON_START){
 		// 0 nothing 1 ask for load 2 load on start
+		if (!item) return;
 		int config = (int)item->IsChecked() * 2;
 		Options.SetInt(LAST_SESSION_CONFIG, config);
 		MenuItem *item = Menubar->FindItem(GLOBAL_ASK_FOR_LOAD_LAST_SESSION);
@@ -963,6 +964,7 @@ void KainoteFrame::OnMenuSelected(wxCommandEvent& event)
 	}
 	else if (id == GLOBAL_ASK_FOR_LOAD_LAST_SESSION){
 		// 0 nothing 1 ask for load 2 load on start
+		if (!item) return;
 		int config = (int)item->IsChecked();
 		Options.SetInt(LAST_SESSION_CONFIG, config);
 		MenuItem *item = Menubar->FindItem(GLOBAL_LOAD_LAST_SESSION_ON_START);
@@ -2639,4 +2641,3 @@ bool KainoteFrame::Layout()
 void KainoteFrame::SetStatusText(const wxString& label, int field) {
 	StatusBar->SetLabelText(field, label); 
 }
-

--- a/Kainote/Menu.cpp
+++ b/Kainote/Menu.cpp
@@ -298,7 +298,6 @@ bool Menu::Destroy(MenuItem *item)
 		}
 
 	}
-	delete item;
 	return false;
 }
 

--- a/Kainote/MisspellReplacer.cpp
+++ b/Kainote/MisspellReplacer.cpp
@@ -183,7 +183,6 @@ void MisspellReplacer::ReplaceChecked()
 	TabPanel *tab = nullptr;
 	Notebook * tabs = Notebook::GetTabs();
 	int oldKeyLine = -1;
-	bool skipTab = false;
 	bool somethingWasChanged = false;
 	size_t size = List->GetCount();
 	for (size_t tt = 0; tt < size; tt++){
@@ -192,14 +191,14 @@ void MisspellReplacer::ReplaceChecked()
 			continue;
 
 		ReplacerSeekResults *SeekResult = (ReplacerSeekResults *)item;
-		tab = SeekResult->tab;
-		// check if skip lines when tab not exist
+		TabPanel *resultTab = SeekResult->tab;
+		if (!resultTab || !tabs || tabs->FindPanel(resultTab, false) == -1 || !resultTab->grid)
+			continue;
+		tab = resultTab;
 		if (tab != oldtab){
-			skipTab = tabs->FindPanel(tab, false) == -1;
 			oldKeyLine = -1;
 		}
-		//skip lines when are out of table range and not existed tab
-		if (skipTab || SeekResult->keyLine >= tab->grid->GetCount())
+		if (SeekResult->keyLine >= tab->grid->GetCount())
 			continue;
 
 		if (SeekResult->keyLine != oldKeyLine){
@@ -773,4 +772,3 @@ Rule::Rule(const wxString & stringRule)
 fail:
 	KaiLog(wxString::Format(_("Reguła \"%s\" jest nieprawidłowa."), stringRule));
 }
-

--- a/Kainote/ModificationChecker.cpp
+++ b/Kainote/ModificationChecker.cpp
@@ -66,7 +66,7 @@ LastModificationChecker::~LastModificationChecker()
 
 int LastModificationChecker::NeedReload(const wxString& fullpath, SYSTEMTIME* lastSaveTime)
 {
-	FILETIME ft;
+	FILETIME ft{};
 	HANDLE ffile = CreateFileW(fullpath.wc_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
 	//return -1 to show that file not exist;
 	if (ffile == INVALID_HANDLE_VALUE)
@@ -74,6 +74,8 @@ int LastModificationChecker::NeedReload(const wxString& fullpath, SYSTEMTIME* la
 
 	if (!GetFileTime(ffile, 0, 0, &ft)) {
 		KaiLogSilent(L"Could not get subtitles modification time");
+		CloseHandle(ffile);
+		return 0;
 	}
 	CloseHandle(ffile);
 	SYSTEMTIME st;

--- a/Kainote/Notebook.cpp
+++ b/Kainote/Notebook.cpp
@@ -132,6 +132,9 @@ Notebook::Notebook(wxWindow *parent, int id)
 
 
 Notebook::~Notebook(){
+	KillTimer(GetHWND(), 9876);
+	if (sthis == this)
+		sthis = nullptr;
 	for (std::vector<TabPanel*>::iterator i = Pages.begin(); i != Pages.end(); i++)
 	{
 		(*i)->Destroy();
@@ -1042,6 +1045,8 @@ int Notebook::GetHeight()
 
 void Notebook::OnResized()
 {
+	if (!sthis)
+		return;
 	KillTimer(sthis->GetHWND(), 9876);
 	int w, h;
 	sthis->GetClientSize(&w, &h);
@@ -1505,28 +1510,31 @@ void Notebook::FindAutoSaveSubstitute(wxString* path, int tab)
 	}
 	SYSTEMTIME highiestTime = {0,0,0,0,0,0,0,0};
 	wxString latestFile;
-	while (1) {
-		if (data.nFileSizeLow == 0) { continue; }
-
-		FILETIME accessTime = data.ftLastWriteTime;
-		SYSTEMTIME accessSystemTime;
-		FileTimeToSystemTime(&accessTime, &accessSystemTime);
-		if (ModifChecker.CheckDate(&highiestTime, &accessSystemTime) ){
-			highiestTime = accessSystemTime;
-			latestFile = wxString(data.cFileName);
+	do {
+		if (data.nFileSizeLow != 0) {
+			FILETIME accessTime = data.ftLastWriteTime;
+			SYSTEMTIME accessSystemTime{};
+			if (FileTimeToSystemTime(&accessTime, &accessSystemTime) &&
+				ModifChecker.CheckDate(&highiestTime, &accessSystemTime)) {
+				highiestTime = accessSystemTime;
+				latestFile = wxString(data.cFileName);
+			}
 		}
-		int result = FindNextFile(h, &data);
-		if (result == ERROR_NO_MORE_FILES || result == 0) { break; }
-	}
+	} while (FindNextFile(h, &data));
 	if (!latestFile.empty()) {
-		FILETIME ft;
+		bool useAutoSave = true;
+		FILETIME ft{};
 		HANDLE ffile = CreateFile(path->wc_str(), 
 			GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
-		GetFileTime(ffile, 0, 0, &ft);
-		CloseHandle(ffile);
-		SYSTEMTIME accessSystemTime;
-		FileTimeToSystemTime(&ft, &accessSystemTime);
-		if (ModifChecker.CheckDate(&accessSystemTime, &highiestTime)) {
+		if (ffile != INVALID_HANDLE_VALUE) {
+			SYSTEMTIME accessSystemTime{};
+			if (GetFileTime(ffile, 0, 0, &ft) &&
+				FileTimeToSystemTime(&ft, &accessSystemTime)) {
+				useAutoSave = ModifChecker.CheckDate(&accessSystemTime, &highiestTime);
+			}
+			CloseHandle(ffile);
+		}
+		if (useAutoSave) {
 			*path = Options.pathfull + L"/Subs/" + latestFile;
 			sthis->loadedRecoverySubs = true;
 		}
@@ -1733,4 +1741,3 @@ EVT_SIZE(Notebook::OnSize)
 EVT_PAINT(Notebook::OnPaint)
 EVT_MOUSE_CAPTURE_LOST(Notebook::OnLostCapture)
 END_EVENT_TABLE()
-

--- a/Kainote/OpennWrite.cpp
+++ b/Kainote/OpennWrite.cpp
@@ -22,6 +22,8 @@
 #include <wx/log.h>
 #include "LogHandler.h"
 #include <uchardet.h>
+#include <limits>
+#include <vector>
 
 
 OpenWrite::OpenWrite()
@@ -60,24 +62,29 @@ bool OpenWrite::FileOpen(const wxString &filename, wxString *riddenText, bool te
 	if (!fname.IsFileReadable()){ return false; }
 	if (test){
 		wxFile filetest;
-		wchar_t b[4];
-		filetest.Open(filename, wxFile::read, wxS_DEFAULT);
-		filetest.Read(b, 4);
+		if (!filetest.Open(filename, wxFile::read, wxS_DEFAULT)) { return false; }
+		wxFileOffset fileLength = filetest.Length();
+		if (fileLength < 0 || static_cast<unsigned long long>(fileLength) >
+			static_cast<unsigned long long>(std::numeric_limits<size_t>::max())) {
+			return false;
+		}
+		std::vector<char> buff(static_cast<size_t>(fileLength));
+		if (!buff.empty() && filetest.Read(buff.data(), buff.size()) != buff.size()) {
+			return false;
+		}
 
-		utf8 = ((static_cast <int>(b[0]) > 48000)) ? true : false;
+		utf8 = buff.size() >= 3 && static_cast<unsigned char>(buff[0]) == 0xEF &&
+			static_cast<unsigned char>(buff[1]) == 0xBB &&
+			static_cast<unsigned char>(buff[2]) == 0xBF;
 		if (!utf8){
-			size_t size = filetest.Length();
-			char *buff = new char[size];
-			filetest.Read(buff, size);
-			utf8 = IsUTF8withoutBOM(buff, size);
+			utf8 = IsUTF8withoutBOM(buff.data(), buff.size());
 			if (!utf8) {
 				wxString result;
-				if (CheckCharSet(buff, size, &result)) {
+				if (CheckCharSet(buff.data(), buff.size(), &result)) {
 					result.MakeUpper();
 					conv = new wxCSConv(result);
 				}
 			}
-			delete[] buff;
 		}
 		filetest.Close();
 	}
@@ -148,55 +155,45 @@ void OpenWrite::CloseFile()
 
 bool OpenWrite::IsUTF8withoutBOM(char* buf, size_t size)
 {
-	bool only_saw_ascii_range = true;
+	if (!buf && size != 0) { return false; }
+	bool onlySawAscii = true;
 	size_t pos = 0;
-	int	more_chars = 0;
-	while (pos < size)
-	{
-		unsigned char ch = buf[pos++];
-		if (ch <= 127)
-		{
-			// 1 byte
-			more_chars = 0;
+	auto isContinuation = [](unsigned char ch) { return ch >= 0x80 && ch <= 0xBF; };
+	while (pos < size) {
+		unsigned char first = static_cast<unsigned char>(buf[pos++]);
+		if (first <= 0x7F) { continue; }
+		onlySawAscii = false;
 
+		if (first >= 0xC2 && first <= 0xDF) {
+			if (pos >= size || !isContinuation(static_cast<unsigned char>(buf[pos++]))) { return false; }
 		}
-		else if (ch >= 194 && ch <= 223)
-		{
-			// 2 Byte
-			more_chars = 1;
-
+		else if (first >= 0xE0 && first <= 0xEF) {
+			if (pos + 1 >= size) { return false; }
+			unsigned char second = static_cast<unsigned char>(buf[pos++]);
+			unsigned char third = static_cast<unsigned char>(buf[pos++]);
+			if (!isContinuation(third) ||
+				(first == 0xE0 ? second < 0xA0 || second > 0xBF :
+				 first == 0xED ? second < 0x80 || second > 0x9F : !isContinuation(second))) {
+				return false;
+			}
 		}
-		else if (ch >= 224 && ch <= 239)
-		{
-			// 3 Byte
-			more_chars = 2;
-
+		else if (first >= 0xF0 && first <= 0xF4) {
+			if (pos + 2 >= size) { return false; }
+			unsigned char second = static_cast<unsigned char>(buf[pos++]);
+			unsigned char third = static_cast<unsigned char>(buf[pos++]);
+			unsigned char fourth = static_cast<unsigned char>(buf[pos++]);
+			if (!isContinuation(third) || !isContinuation(fourth) ||
+				(first == 0xF0 ? second < 0x90 || second > 0xBF :
+				 first == 0xF4 ? second < 0x80 || second > 0x8F : !isContinuation(second))) {
+				return false;
+			}
 		}
-		else if (ch >= 240 && ch <= 244)
-		{
-			// 4 Byte
-			more_chars = 3;
-
-		}
-		else
-		{
-			//if this will not work, maybe set continue;
-			continue;
-			//return false; // Not utf8
-		}
-		// Check secondary chars are in range if we are expecting any
-		while (more_chars && pos < size)
-		{
-			only_saw_ascii_range = false; // Seen non-ascii chars now
-			ch = buf[pos++];
-			if (ch < 128 || ch > 205) { return false; } // Not utf8
-			--more_chars;
+		else {
+			return false;
 		}
 	}
 
-	if (only_saw_ascii_range){ return false; }
-
-	return true;
+	return !onlySawAscii;
 
 }
 
@@ -206,15 +203,17 @@ bool OpenWrite::CheckCharSet(char* buf, size_t size, wxString* result)
 	if (!detector)
 		return false;
 
-	int intresult = uchardet_handle_data(detector, buf, size);
+	if (uchardet_handle_data(detector, buf, size) != 0) {
+		uchardet_delete(detector);
+		return false;
+	}
 	uchardet_data_end(detector);
 	const char* encoding = uchardet_get_charset(detector);
-	if (encoding && *encoding)
+	bool detected = encoding && *encoding;
+	if (detected)
 		*result = wxString(encoding);
-	else
-		return false;
 
 	uchardet_delete(detector);
 
-	return true;
+	return detected;
 }

--- a/Kainote/OptionsDialog.cpp
+++ b/Kainote/OptionsDialog.cpp
@@ -932,7 +932,6 @@ OptionsDialog::OptionsDialog(wxWindow* parent)
 			DialogColorPicker *dcp = DialogColorPicker::Get(List, itemc->col);
 			wxPoint mst = wxGetMousePosition();
 			wxSize siz = dcp->GetSize();
-			siz.x;
 			wxRect rc = wxGetClientDisplayRect();
 			mst.x -= (siz.x / 2);
 			mst.x = MID(rc.x, mst.x, rc.width - siz.x);

--- a/Kainote/Provider.h
+++ b/Kainote/Provider.h
@@ -21,6 +21,7 @@
 #include "SubsGrid.h"
 #include "Provider.h"
 #include "TabPanel.h"
+#include <atomic>
 #include <vector>
 #include <thread>
 #include "../Thirdparty/ffms2/include/ffms.h"
@@ -76,15 +77,15 @@ public:
 	void OpenKeyframes(const wxString& filename);
 	void SetPosition(int time, bool starttime, bool refteshAudio = true);
 	bool AudioNotInitialized() {
-		return audioNotInitialized;
+		return audioNotInitialized.load();
 	}
 	float GetAudioProgress() {
-		return m_audioProgress;
+		return m_audioProgress.load();
 	}
 protected:
 	Provider(const wxString& filename, RendererVideo* renderer);
-	volatile bool audioNotInitialized = true;
-	volatile float m_audioProgress = 0;
+	std::atomic<bool> audioNotInitialized{ true };
+	std::atomic<float> m_audioProgress{ 0 };
 	RendererVideo* m_renderer = nullptr;
 	int m_width = -1;
 	int m_height = -1;

--- a/Kainote/ProviderDummy.cpp
+++ b/Kainote/ProviderDummy.cpp
@@ -26,7 +26,7 @@ ProviderDummy::~ProviderDummy()
 {
 	if (m_thread) {
 		SetEvent(m_eventKillSelf);
-		WaitForSingleObject(m_thread, 20000);
+		WaitForSingleObject(m_thread, INFINITE);
 		CloseHandle(m_thread);
 		m_thread = nullptr;
 	}
@@ -260,6 +260,7 @@ void ProviderDummy::Processing()
 			byte* buff = (byte*)m_renderer->m_FrameBuffer;
 			int acttime;
 			while (1) {
+				if (WaitForSingleObject(m_eventKillSelf, 0) == WAIT_OBJECT_0) { return; }
 
 				if (m_renderer->m_Frame != m_lastFrame) {
 					m_renderer->m_Time = m_timecodes[m_renderer->m_Frame];
@@ -289,12 +290,13 @@ void ProviderDummy::Processing()
 				if (tdiff > 0) { Sleep(tdiff); }
 				else if (tdiff < -20) {
 					while (1) {
+						if (m_renderer->m_Frame >= m_numFrames) {
+							m_renderer->m_Frame = m_numFrames - 1;
+							m_renderer->m_Time = m_renderer->m_PlayEndTime;
+							break;
+						}
 						int frameTime = m_timecodes[m_renderer->m_Frame];
-						if (frameTime >= acttime || frameTime >= m_renderer->m_PlayEndTime || m_renderer->m_Frame >= m_numFrames) {
-							if (m_renderer->m_Frame >= m_numFrames) {
-								m_renderer->m_Frame = m_numFrames - 1;
-								m_renderer->m_Time = m_renderer->m_PlayEndTime;
-							}
+						if (frameTime >= acttime || frameTime >= m_renderer->m_PlayEndTime) {
 							break;
 						}
 						else {
@@ -316,4 +318,3 @@ void ProviderDummy::Processing()
 
 	}
 }
-

--- a/Kainote/ProviderFFMS2.cpp
+++ b/Kainote/ProviderFFMS2.cpp
@@ -133,6 +133,7 @@ void ProviderFFMS2::Processing()
 			unsigned char* buff = m_renderer->m_FrameBuffer;
 			int acttime;
 			while (1) {
+				if (WaitForSingleObject(m_eventKillSelf, 0) == WAIT_OBJECT_0) { return; }
 
 				if (m_renderer->m_Frame != m_lastFrame) {
 					m_renderer->m_Time = m_timecodes[m_renderer->m_Frame];
@@ -167,13 +168,13 @@ void ProviderFFMS2::Processing()
 				if (tdiff > 0) { Sleep(tdiff); }
 				else if (tdiff < -20) {
 					while (1) {
+						if (m_renderer->m_Frame >= m_numFrames) {
+							m_renderer->m_Frame = m_numFrames - 1;
+							m_renderer->m_Time = m_renderer->m_PlayEndTime;
+							break;
+						}
 						int frameTime = m_timecodes[m_renderer->m_Frame];
-						if (frameTime >= acttime || frameTime >= m_renderer->m_PlayEndTime || 
-							m_renderer->m_Frame >= m_numFrames) {
-							if (m_renderer->m_Frame >= m_numFrames) {
-								m_renderer->m_Frame = m_numFrames - 1;
-								m_renderer->m_Time = m_renderer->m_PlayEndTime;
-							}
+						if (frameTime >= acttime || frameTime >= m_renderer->m_PlayEndTime) {
 							break;
 						}
 						else {
@@ -528,7 +529,7 @@ ProviderFFMS2::~ProviderFFMS2()
 {
 	if (m_thread) {
 		SetEvent(m_eventKillSelf);
-		WaitForSingleObject(m_thread, 20000);
+		WaitForSingleObject(m_thread, INFINITE);
 		CloseHandle(m_thread);
 		m_thread = nullptr;
 	}
@@ -723,7 +724,7 @@ bool ProviderFFMS2::RAMCache()
 			GetAudio(m_cache[i], pos, halfsize);
 			pos += halfsize;
 		}
-		m_audioProgress = ((float)i / (float)(m_blockNum - 1));
+		m_audioProgress = (m_blockNum > 1) ? ((float)i / (float)(m_blockNum - 1)) : 1.f;
 		if (m_stopLoadingAudio) {
 			m_blockNum = i + 1;
 			break;
@@ -828,28 +829,29 @@ void ProviderFFMS2::DeleteOldAudioCache()
 		kat.GetAllFiles(path, &audioCaches, emptyString, wxDIR_FILES);
 	}
 	if (audioCaches.size() <= maxAudio) { return; }
-	FILETIME ft;
-	SYSTEMTIME st;
-	std::map<unsigned __int64, int> dates;
-	unsigned __int64 datetime;
+	std::multimap<unsigned __int64, size_t> dates;
 	for (size_t i = 0; i < audioCaches.size(); i++) {
 		HANDLE ffile = CreateFile(audioCaches[i].wc_str(), GENERIC_READ, FILE_SHARE_DELETE, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
 		if (ffile != INVALID_HANDLE_VALUE) {
-			GetFileTime(ffile, 0, &ft, 0);
+			FILETIME ft{};
+			SYSTEMTIME st{};
+			const bool haveTimestamp = GetFileTime(ffile, 0, &ft, 0) &&
+				FileTimeToSystemTime(&ft, &st);
 			CloseHandle(ffile);
-			FileTimeToSystemTime(&ft, &st);
+			if (!haveTimestamp)
+				continue;
 			if (st.wYear > 3000) { st.wYear = 3000; }
-			datetime = (st.wYear * 980294400000) + (st.wMonth * 2678400000) + (st.wDay * 86400000) + (st.wHour * 3600000) + (st.wMinute * 60000) + (st.wSecond * 1000) + st.wMilliseconds;
-			dates[datetime] = i;
+			const unsigned __int64 datetime = (st.wYear * 980294400000) + (st.wMonth * 2678400000) + (st.wDay * 86400000) + (st.wHour * 3600000) + (st.wMinute * 60000) + (st.wSecond * 1000) + st.wMilliseconds;
+			dates.emplace(datetime, i);
 		}
 
 	}
-	int count = 0;
-	int diff = audioCaches.size() - maxAudio;
+	size_t count = 0;
+	const size_t diff = audioCaches.size() - maxAudio;
 	for (auto cur = dates.begin(); cur != dates.end(); cur++) {
 		if (count >= diff) { break; }
-		int isgood = _wremove(audioCaches[cur->second].wchar_str());
-		count++;
+		if (_wremove(audioCaches[cur->second].wchar_str()) == 0)
+			count++;
 	}
 
 }
@@ -910,4 +912,3 @@ bool ProviderFFMS2::HasVideo()
 {
 	return m_videoSource != nullptr;
 }
-

--- a/Kainote/RendererGStreamer.cpp
+++ b/Kainote/RendererGStreamer.cpp
@@ -178,6 +178,7 @@ void RendererGStreamer::TearDown()
 	std::lock_guard<std::mutex> lock(m_LinuxPendingFrameMutex);
 	m_LinuxPendingFrame.clear();
 	m_LinuxPresentFrame.clear();
+	m_LinuxPendingTime = -1;
 }
 
 bool RendererGStreamer::WaitPreroll()
@@ -253,7 +254,7 @@ bool RendererGStreamer::QueryVideoInfo()
 
 	gint64 dur = 0;
 	if (gst_element_query_duration(m_Pipeline, GST_FORMAT_TIME, &dur) && dur > 0)
-		m_DurationMs = (int)(dur / GST_MSECOND);
+		m_DurationMs.store((int)(dur / GST_MSECOND));
 	return true;
 }
 
@@ -265,6 +266,9 @@ bool RendererGStreamer::OpenFile(const wxString &fname, int subsFlag, bool vobsu
 	EnsureGstInit();
 
 	m_Time = 0;
+	m_StreamTimeMs.store(0);
+	m_StreamPlayEndMs.store(0);
+	m_DurationMs.store(0);
 	m_Frame = 0;
 	m_ReachedPlayEnd.store(false);
 
@@ -406,10 +410,12 @@ void RendererGStreamer::HandleSample(GstSample *sample)
 	if (w <= 0 || h <= 0)
 		return;
 
+	int frameTimeMs = m_StreamTimeMs.load();
 	if (GST_BUFFER_PTS_IS_VALID(buf)) {
-		const int ms = (int)(GST_BUFFER_PTS(buf) / GST_MSECOND);
-		m_Time = ms;
-		if (m_PlayEndTime && ms >= m_PlayEndTime && !m_ReachedPlayEnd.exchange(true)) {
+		frameTimeMs = (int)(GST_BUFFER_PTS(buf) / GST_MSECOND);
+		m_StreamTimeMs.store(frameTimeMs);
+		const int playEndMs = m_StreamPlayEndMs.load();
+		if (playEndMs && frameTimeMs >= playEndMs && !m_ReachedPlayEnd.exchange(true)) {
 			wxQueueEvent(videoControl, new wxCommandEvent(wxEVT_COMMAND_MENU_SELECTED, VIDEO_PLAY_PAUSE));
 			wxQueueEvent(videoControl, new wxCommandEvent(wxEVT_COMMAND_MENU_SELECTED, ID_REFRESH_TIME));
 		}
@@ -438,7 +444,7 @@ void RendererGStreamer::HandleSample(GstSample *sample)
 
 		// Subtitles, then (fullscreen) progress bar, composited into the frame.
 		if (m_SubsOpened)
-			m_SubsProvider->Draw(m_FrameBuffer, m_Time);
+			m_SubsProvider->Draw(m_FrameBuffer, frameTimeMs);
 
 		if (m_PbValid.load() && videoControl->m_FullScreenProgressBar) {
 			std::lock_guard<std::mutex> pbLock(m_PbMutex);
@@ -455,6 +461,7 @@ void RendererGStreamer::HandleSample(GstSample *sample)
 		if (m_LinuxPendingFrame.size() != frameBytes)
 			m_LinuxPendingFrame.resize(frameBytes);
 		memcpy(m_LinuxPendingFrame.data(), m_FrameBuffer, frameBytes);
+		m_LinuxPendingTime = frameTimeMs;
 	}
 	gst_video_frame_unmap(&vframe);
 	QueueLinuxRender();
@@ -510,15 +517,22 @@ void RendererGStreamer::BusLoop()
 			KaiLog(wxString::Format(L"GStreamer: %s", wxString::FromUTF8(err ? err->message : "error")));
 			if (err) g_error_free(err);
 			g_free(dbg);
-			// Don't leave the UI stuck "playing" on a fatal pipeline error.
-			if (m_State == Playing)
-				wxQueueEvent(videoControl, new wxCommandEvent(wxEVT_COMMAND_MENU_SELECTED, VIDEO_PLAY_PAUSE));
+			// m_State is UI-owned.
+			auto alive = m_LinuxAlive;
+			if (auto *app = wxTheApp) {
+				app->CallAfter([this, alive]() {
+					if (alive->load() && m_State == Playing)
+						wxQueueEvent(videoControl,
+							new wxCommandEvent(wxEVT_COMMAND_MENU_SELECTED, VIDEO_PLAY_PAUSE));
+				});
+				wxWakeUpIdle();
+			}
 			break;
 		}
 		case GST_MESSAGE_DURATION_CHANGED: {
 			gint64 dur = 0;
 			if (gst_element_query_duration(m_Pipeline, GST_FORMAT_TIME, &dur) && dur > 0)
-				m_DurationMs = (int)(dur / GST_MSECOND);
+				m_DurationMs.store((int)(dur / GST_MSECOND));
 			break;
 		}
 		default:
@@ -552,6 +566,7 @@ bool RendererGStreamer::Play(int end)
 	}
 
 	m_PlayEndTime = (end > 0) ? end : 0;
+	m_StreamPlayEndMs.store(m_PlayEndTime);
 	m_ReachedPlayEnd.store(false);
 	if (m_Time < GetDuration() - m_FrameDuration)
 		gst_element_set_state(m_Pipeline, GST_STATE_PLAYING);
@@ -579,13 +594,15 @@ bool RendererGStreamer::Stop()
 	if (m_State == Playing) {
 		SetThreadExecutionState(ES_CONTINUOUS);
 		m_State = Stopped;
+		m_PlayEndTime = 0;
+		m_StreamPlayEndMs.store(0);
 		if (m_Pipeline) {
 			gst_element_set_state(m_Pipeline, GST_STATE_PAUSED);
 			gst_element_seek_simple(m_Pipeline, GST_FORMAT_TIME,
 				(GstSeekFlags)(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT), 0);
 		}
-		m_PlayEndTime = 0;
 		m_Time = 0;
+		m_StreamTimeMs.store(0);
 		return true;
 	}
 	return false;
@@ -595,6 +612,7 @@ void RendererGStreamer::SetPosition(int _time, bool starttime, bool corect, bool
 {
 	if (!m_Pipeline)
 		return;
+	m_StreamPlayEndMs.store(0);
 	m_Time = MID(0, _time, GetDuration());
 	if (corect) {
 		m_Time /= m_FrameDuration;
@@ -602,6 +620,7 @@ void RendererGStreamer::SetPosition(int _time, bool starttime, bool corect, bool
 		m_Time *= m_FrameDuration;
 	}
 	m_PlayEndTime = 0;
+	m_StreamTimeMs.store(m_Time);
 	m_ReachedPlayEnd.store(false);
 	gst_element_seek_simple(m_Pipeline, GST_FORMAT_TIME,
 		(GstSeekFlags)(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT),
@@ -686,9 +705,9 @@ int RendererGStreamer::GetDuration()
 	if (m_Pipeline) {
 		gint64 dur = 0;
 		if (gst_element_query_duration(m_Pipeline, GST_FORMAT_TIME, &dur) && dur > 0)
-			m_DurationMs = (int)(dur / GST_MSECOND);
+			m_DurationMs.store((int)(dur / GST_MSECOND));
 	}
-	return m_DurationMs;
+	return m_DurationMs.load();
 }
 
 void RendererGStreamer::GetVideoSize(int *width, int *height)

--- a/Kainote/RendererGStreamer.h
+++ b/Kainote/RendererGStreamer.h
@@ -106,7 +106,9 @@ private:
 	std::atomic_bool m_PbValid{ false };
 
 	int m_VolumeMb = 0;                 // cached volume, millibels (0 = full, <0 attenuation)
-	int m_DurationMs = 0;               // cached duration
+	std::atomic_int m_StreamTimeMs{ 0 }; // appsink timestamp shared with the UI thread
+	std::atomic_int m_StreamPlayEndMs{ 0 };
+	std::atomic_int m_DurationMs{ 0 };   // cached duration (bus + UI threads)
 	long m_ArX = 0;
 	long m_ArY = 0;
 	std::atomic_bool m_ReachedPlayEnd{ false };

--- a/Kainote/RendererVideo.cpp
+++ b/Kainote/RendererVideo.cpp
@@ -139,10 +139,19 @@ void RendererVideo::QueueLinuxRender()
 	wxTheApp->CallAfter([this, alive]() {
 		if (!alive->load())
 			return; // renderer was destroyed before this ran
-		m_LinuxRenderQueued.store(false);
 		{
 			std::lock_guard<std::mutex> lock(m_LinuxPendingFrameMutex);
-			m_LinuxPresentFrame.swap(m_LinuxPendingFrame);
+			if (!m_LinuxPendingFrame.empty()) {
+				m_LinuxPresentFrame.swap(m_LinuxPendingFrame);
+				// Prevent empty callbacks from restoring the old frame.
+				m_LinuxPendingFrame.clear();
+				if (m_LinuxPendingTime >= 0) {
+					m_Time = m_LinuxPendingTime;
+					m_LinuxPendingTime = -1;
+				}
+			}
+			// Reset under the producer lock to avoid missed frames.
+			m_LinuxRenderQueued.store(false);
 		}
 		if (m_State != None && !m_LinuxPresentFrame.empty()) {
 			wxWindow* renderWindow = (videoControl->m_IsFullscreen && videoControl->m_FullScreenWindow) ?
@@ -976,4 +985,3 @@ PlaybackState RendererVideo::GetState()
 {
 	return m_State;
 }
-

--- a/Kainote/RendererVideo.h
+++ b/Kainote/RendererVideo.h
@@ -178,6 +178,8 @@ public:
 	std::mutex m_LinuxPendingFrameMutex;
 	std::vector<unsigned char> m_LinuxPendingFrame;
 	std::vector<unsigned char> m_LinuxPresentFrame;
+	// Timestamp paired with m_LinuxPendingFrame under the same mutex.
+	int m_LinuxPendingTime = -1;
 	std::atomic_uint m_LinuxPresentedFrames{ 0 };
 	// Outlives the renderer (copied into the QueueLinuxRender CallAfter lambda),
 	// so a queued present can't touch a renderer that was deleted meanwhile

--- a/Kainote/SpellCheckerDialog.cpp
+++ b/Kainote/SpellCheckerDialog.cpp
@@ -91,6 +91,8 @@ SpellCheckerDialog::SpellCheckerDialog(KainoteFrame *parent)
 	Bind(wxEVT_COMMAND_BUTTON_CLICKED, [=, this](wxCommandEvent &evt){
 		Destroy();
 	}, ID_CLOSE_DIALOG);
+	// This unretained modeless dialog must destroy itself on close.
+	Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent&) { Destroy(); });
 	Bind(wxEVT_ACTIVATE, &SpellCheckerDialog::OnActive, this);
 	SetEscapeId(ID_CLOSE_DIALOG);
 	SetEnterId(ID_REPLACE);
@@ -339,4 +341,3 @@ void SpellCheckerDialog::OnActive(wxActivateEvent &evt)
 		}
 	}
 }
-

--- a/Kainote/SubsGridBase.cpp
+++ b/Kainote/SubsGridBase.cpp
@@ -40,6 +40,9 @@
 #include <wx/ffile.h>
 #include <wx/window.h>
 #include <locale>
+#include <limits>
+#include <new>
+#include <vector>
 
 SubsGridBase* SubsGridBase::CG1 = NULL;
 SubsGridBase* SubsGridBase::CG2 = NULL;
@@ -1808,19 +1811,26 @@ void SubsGridBase::CompareTexts(compareData &firstCompare, compareData &secondCo
 
 
 	size_t l1 = first.length(), l2 = second.length();
-	size_t sz = (l1 + 1) * (l2 + 1) * sizeof(size_t);
+	if (l1 == std::numeric_limits<size_t>::max() || l2 == std::numeric_limits<size_t>::max() ||
+		(l1 + 1) > std::numeric_limits<size_t>::max() / (l2 + 1)) {
+		KaiLog(L"text comparison is too large");
+		return;
+	}
+	size_t cellCount = (l1 + 1) * (l2 + 1);
 	size_t w = l2 + 1;
-	size_t* dpt;
 	size_t i1, i2;
-	dpt = new size_t[sz];
-
-	if (dpt == nullptr)
-	{
+	std::vector<size_t> dpt;
+	if (cellCount > dpt.max_size()) {
 		KaiLog(L"memory allocation failed");
 		return;
 	}
-
-	memset(dpt, 0, sz);
+	try {
+		dpt.assign(cellCount, 0);
+	}
+	catch (const std::bad_alloc&) {
+		KaiLog(L"memory allocation failed");
+		return;
+	}
 
 	for (i1 = 1; i1 <= l1; i1++){
 		for (i2 = 1; i2 <= l2; i2++)
@@ -1877,8 +1887,6 @@ void SubsGridBase::CompareTexts(compareData &firstCompare, compareData &secondCo
 		secondCompare.push_back(ssecond);
 		secondCompare.push_back((l2 - i2) - 1);
 	}
-
-	delete dpt;
 }
 
 void SubsGridBase::RemoveComparison()
@@ -1976,7 +1984,6 @@ size_t SubsGridBase::GetDialoguePosition(size_t keyPosition)
 	}
 	return dialogues;
 }
-
 
 
 

--- a/Kainote/SubsGridWindow.cpp
+++ b/Kainote/SubsGridWindow.cpp
@@ -491,9 +491,10 @@ void SubsGridWindow::OnPaint(wxPaintEvent& event)
 					wxBitmap arrow = wxBITMAP_PNG(L"arrow_list");
 					// GetDialogueKey was made for loops no checks
 					Dialogue *nextDial = (key < GetCount() - 1) ? GetDialogue(key + 1) : nullptr;
-					if (nextDial && nextDial->treeState == TREE_CLOSED)
-						if(arrow.IsOk())
+					if (nextDial && nextDial->treeState == TREE_CLOSED) {
+						if (arrow.IsOk())
 							tdc.DrawBitmap(arrow, posX + 6, posY + 5);
+					}
 					else{
 						wxBitmap bmp(wxBITMAP_PNG(L"arrow_list"));
 						wxImage img = bmp.ConvertToImage();

--- a/Kainote/Toolbar.cpp
+++ b/Kainote/Toolbar.cpp
@@ -29,12 +29,13 @@
 
 KaiToolbar::KaiToolbar(wxWindow *Parent, MenuBar *mainm, int id)
 	:wxWindow(Parent, -1, wxDefaultPosition, wxSize(24, -1))
-	, bmp(nullptr)
+	, alignment(0)
 	, Clicked(false)
 	, wasmoved(false)
-	, wh(thickness)
+	, wh(24)
 	, oldelem(-1)
 	, sel(-1)
+	, bmp(nullptr)
 	, mb(mainm)
 {
 	alignment = Options.GetInt(TOOLBAR_ALIGNMENT);
@@ -387,7 +388,8 @@ void KaiToolbar::OnToolbarOpts(wxCommandEvent &event)
 	point = GetParent()->ClientToScreen(point);
 	wxSize toolbarSize = GetClientSize();
 
-	int fw, fh, width = 0;
+	int fw = 0, fh = 0, width = 0;
+	GetTextExtent(L"X", &fw, &fh);
 
 	int ysize = ids.size();
 	for (int i = 0; i < ysize; i++){
@@ -694,4 +696,3 @@ EVT_PAINT(ToolbarMenu::OnPaint)
 EVT_MOUSE_CAPTURE_LOST(ToolbarMenu::OnLostCapture)
 EVT_SCROLL(ToolbarMenu::OnScroll)
 END_EVENT_TABLE()
-

--- a/Kainote/UpdateChecker.cpp
+++ b/Kainote/UpdateChecker.cpp
@@ -253,13 +253,8 @@ void UpdateChecker::Update(bool closeProgram /*= true*/)
 			return;
 		}
 	}
-	wchar_t **cmdline = new wchar_t*[3];
-	cmdline[0] = editorbuf.data();
-	cmdline[1] = sfnamebuf.data();
-	cmdline[2] = versionK.data();
-	cmdline[3] = 0;
+	wchar_t *cmdline[] = { editorbuf.data(), sfnamebuf.data(), versionK.data(), nullptr };
 	long res = wxExecute(cmdline);
-	delete[] cmdline;
 }
 
 bool UpdateChecker::CheckForUpdate()

--- a/Kainote/VideoBox.cpp
+++ b/Kainote/VideoBox.cpp
@@ -70,13 +70,13 @@ CRecycleFile::CRecycleFile()
 
 int CRecycleFile::Recycle(const wchar_t *pszPath, BOOL bDelete)
 {
-
-	wchar_t buf[_MAX_PATH + 1];
-	wcscpy(buf, pszPath);
-	buf[wcslen(buf) + 1] = 0;
+	if (!pszPath)
+		return 1;
+	std::wstring from(pszPath);
+	from.push_back(L'\0');
 
 	wFunc = FO_DELETE;
-	pFrom = buf;
+	pFrom = from.c_str();
 	pTo = nullptr;
 	if (bDelete) {
 		fFlags &= ~FOF_ALLOWUNDO;
@@ -84,7 +84,9 @@ int CRecycleFile::Recycle(const wchar_t *pszPath, BOOL bDelete)
 	else {
 		fFlags |= FOF_ALLOWUNDO;
 	}
-	return SHFileOperation(this);
+	int result = SHFileOperation(this);
+	pFrom = nullptr;
+	return result;
 
 }
 
@@ -1315,7 +1317,7 @@ void VideoBox::ChangeOnScreenResolution(TabPanel *tab)
 
 void VideoBox::RefreshTime()
 {
-	if (!renderer && GetState() != None)
+	if (!renderer)
 		return;
 
 	SubsTime videoTime;
@@ -1979,4 +1981,3 @@ EVT_ERASE_BACKGROUND(VideoBox::OnErase)
 EVT_BUTTON(ID_END_OF_STREAM, VideoBox::OnEndFile)
 EVT_MOUSE_CAPTURE_LOST(VideoBox::OnLostCapture)
 END_EVENT_TABLE()
-

--- a/Kainote/VideoBox.h
+++ b/Kainote/VideoBox.h
@@ -25,6 +25,7 @@
 #include "VideoBox.h"
 #include "Provider.h"
 #include "TabPanel.h"
+#include <atomic>
 
 class Provider;
 class Fullscreen;
@@ -192,7 +193,7 @@ private:
 	std::vector<RECT> MonRects;
 	bool m_IsOnAnotherMonitor = false;
 	bool m_IsFullscreen = false;
-	bool m_FullScreenProgressBar = false;
+	std::atomic_bool m_FullScreenProgressBar{ false };
 	bool m_PanelOnFullscreen = false;
 	int m_PanelHeight = 44;
 	long m_AspectRatioX, m_AspectRatioY;
@@ -250,5 +251,4 @@ enum
 			}\
 	font->DrawTextW(nullptr, text.wchar_str(), -1, &rect, align, color );
 #endif
-
 

--- a/Kainote/Visuals.cpp
+++ b/Kainote/Visuals.cpp
@@ -245,7 +245,11 @@ void Visuals::RenderSubs(wxString *subs, bool redraw /*= true*/)
 {
 	//visual, renderer should exist
 	RendererVideo *renderer = tab->video->GetRenderer();
-	if (renderer && !renderer->OpenSubs(OPEN_HAS_OWN_TEXT, true, subs)){ KaiLog(_("Nie można otworzyć napisów")); }
+	if (!renderer) {
+		delete subs;
+		return;
+	}
+	if (!renderer->OpenSubs(OPEN_HAS_OWN_TEXT, true, subs)){ KaiLog(_("Nie można otworzyć napisów")); }
 	tab->video->SetVisualEdition(true);
 	if (redraw){ tab->video->Render(); }
 }
@@ -1294,4 +1298,3 @@ void Visuals::Curve(int pos, std::vector<ClipPoint>* vectorPoints,
 	p_y = b[0] + b[1] + b[2] + b[3];
 	table->push_back(D3DXVECTOR2(p_x, p_y));
 }
-

--- a/Kainote/findreplace.cpp
+++ b/Kainote/findreplace.cpp
@@ -171,7 +171,6 @@ void FindReplace::ReplaceChecked()
 		TabPanel *tab = nullptr;
 		int oldKeyLine = -1;
 		int numOfChanges = 0;
-		bool skipTab = false;
 		bool skipLine = false;
 		bool lastIsTextTl = false;
 		size_t size = List->GetCount();
@@ -181,15 +180,16 @@ void FindReplace::ReplaceChecked()
 				continue;
 
 			SeekResults *SeekResult = (SeekResults *)item;
-			tab = SeekResult->tab;
-			// check if skip lines when tab not exist
+			TabPanel *resultTab = SeekResult->tab;
+			if (!resultTab || !Kai || !Kai->Tabs ||
+				Kai->Tabs->FindPanel(resultTab, false) == -1 || !resultTab->grid)
+				continue;
+			tab = resultTab;
 			if (tab != oldtab){
-				skipTab = Kai->Tabs->FindPanel(tab, false) == -1;
 				oldKeyLine = -1;
 				lastIsTextTl = false;
 			}
-			//skip lines when are out of table range and not existed tab
-			if (skipTab || SeekResult->keyLine >= tab->grid->GetCount())
+			if (SeekResult->keyLine >= tab->grid->GetCount())
 				continue;
 
 			Dialogue *Dialc = tab->grid->CopyDialogueF(SeekResult->keyLine, true, false);
@@ -1614,4 +1614,3 @@ int FindReplace::ReplaceCheckedInSubs(std::vector<SeekResults *> &results, const
 
 	return numOfChanges;
 }
-

--- a/Kainote/platform.h
+++ b/Kainote/platform.h
@@ -10,6 +10,7 @@
 #include <ctime>
 #include <cwctype>
 #include <chrono>
+#include <cctype>
 #include <string>
 #include <filesystem>
 #include <cstdio>
@@ -33,6 +34,7 @@
 #include <atomic>
 #include <memory>
 #include <map>
+#include <set>
 #include <sys/wait.h>
 #include <fontconfig/fontconfig.h>
 #include <wx/app.h>
@@ -41,6 +43,7 @@
 #include <wx/panel.h>
 #include <wx/intl.h>
 #include <wx/power.h>
+#include <wx/utils.h>
 
 #ifndef __linux__
 #define __linux__ 1
@@ -74,8 +77,9 @@ using BYTE = unsigned char;
 using WORD = std::uint16_t;
 using DWORD = std::uint32_t;
 using UINT = unsigned int;
-using ULONG = unsigned long;
-using LONG = long;
+// Win32 LONG, ULONG, and HRESULT remain 32-bit on LP64 hosts.
+using ULONG = std::uint32_t;
+using LONG = std::int32_t;
 using BOOL = int;
 #ifndef TRUE
 #define TRUE 1
@@ -83,7 +87,7 @@ using BOOL = int;
 #endif
 using BOOLEAN = int;
 using VOID = void;
-using HRESULT = long;
+using HRESULT = std::int32_t;
 using WCHAR = wchar_t;
 using LPCWSTR = const wchar_t*;
 using LPWSTR = wchar_t*;
@@ -221,19 +225,65 @@ inline void GetLocalTime(SYSTEMTIME* st) {
     std::time_t t=std::time(nullptr); std::tm tm{}; localtime_r(&t,&tm);
     st->wYear=tm.tm_year+1900; st->wMonth=tm.tm_mon+1; st->wDay=tm.tm_mday; st->wDayOfWeek=tm.tm_wday; st->wHour=tm.tm_hour; st->wMinute=tm.tm_min; st->wSecond=tm.tm_sec; st->wMilliseconds=0;
 }
+constexpr std::uint64_t KAINOTE_FILETIME_TICKS_PER_SECOND = 10000000ULL;
+constexpr std::int64_t KAINOTE_FILETIME_UNIX_EPOCH_OFFSET = 11644473600LL;
+inline bool kainote_timespec_to_filetime(const timespec& value, FILETIME* output) {
+    if (!output || value.tv_nsec < 0 || value.tv_nsec >= 1000000000L)
+        return false;
+    const std::int64_t unixSeconds = static_cast<std::int64_t>(value.tv_sec);
+    const std::int64_t maxUnixSeconds = static_cast<std::int64_t>(
+        std::numeric_limits<std::uint64_t>::max() / KAINOTE_FILETIME_TICKS_PER_SECOND) -
+        KAINOTE_FILETIME_UNIX_EPOCH_OFFSET;
+    if (unixSeconds < -KAINOTE_FILETIME_UNIX_EPOCH_OFFSET ||
+        unixSeconds > maxUnixSeconds)
+        return false;
+    const std::uint64_t ticks =
+        static_cast<std::uint64_t>(unixSeconds + KAINOTE_FILETIME_UNIX_EPOCH_OFFSET) *
+            KAINOTE_FILETIME_TICKS_PER_SECOND +
+        static_cast<std::uint64_t>(value.tv_nsec) / 100ULL;
+    output->dwLowDateTime = static_cast<DWORD>(ticks);
+    output->dwHighDateTime = static_cast<DWORD>(ticks >> 32);
+    return true;
+}
+inline bool kainote_filetime_to_timespec(const FILETIME* input, timespec* output) {
+    if (!input || !output)
+        return false;
+    const std::uint64_t ticks =
+        (static_cast<std::uint64_t>(input->dwHighDateTime) << 32) |
+        input->dwLowDateTime;
+    const std::int64_t unixSeconds = static_cast<std::int64_t>(
+        ticks / KAINOTE_FILETIME_TICKS_PER_SECOND) -
+        KAINOTE_FILETIME_UNIX_EPOCH_OFFSET;
+    const std::time_t seconds = static_cast<std::time_t>(unixSeconds);
+    if (static_cast<std::int64_t>(seconds) != unixSeconds)
+        return false;
+    output->tv_sec = seconds;
+    output->tv_nsec = static_cast<long>(
+        (ticks % KAINOTE_FILETIME_TICKS_PER_SECOND) * 100ULL);
+    return true;
+}
 inline bool SystemTimeToFileTime(const SYSTEMTIME* st, FILETIME* ft) {
-    if (!st || !ft) return false;
+    if (!st || !ft || st->wYear < 1601 || st->wMonth < 1 || st->wMonth > 12 ||
+        st->wDay < 1 || st->wDay > 31 || st->wHour > 23 || st->wMinute > 59 ||
+        st->wSecond > 59 || st->wMilliseconds > 999) return false;
     std::tm tm{}; tm.tm_year=st->wYear-1900; tm.tm_mon=st->wMonth-1; tm.tm_mday=st->wDay; tm.tm_hour=st->wHour; tm.tm_min=st->wMinute; tm.tm_sec=st->wSecond;
-    auto t = timegm(&tm); auto v=static_cast<std::uint64_t>(t);
-    ft->dwLowDateTime=static_cast<DWORD>(v); ft->dwHighDateTime=static_cast<DWORD>(v>>32); return true;
+    const std::time_t t = timegm(&tm);
+    const timespec value{t, static_cast<long>(st->wMilliseconds) * 1000000L};
+    return kainote_timespec_to_filetime(value, ft);
 }
 inline bool FileTimeToSystemTime(const FILETIME* ft, SYSTEMTIME* st) {
     if (!ft || !st) return false;
-    std::uint64_t v=((std::uint64_t)ft->dwHighDateTime<<32)|ft->dwLowDateTime; kainote_time_t_to_system((std::time_t)v, st); return true;
+    timespec value{};
+    if (!kainote_filetime_to_timespec(ft, &value)) return false;
+    std::tm tm{};
+    if (!gmtime_r(&value.tv_sec, &tm)) return false;
+    kainote_tm_to_system(tm, st);
+    st->wMilliseconds = static_cast<WORD>(value.tv_nsec / 1000000L);
+    return true;
 }
 inline std::time_t kainote_filetime_to_time_t(const FILETIME* ft) {
-    std::uint64_t v = ((std::uint64_t)ft->dwHighDateTime << 32) | ft->dwLowDateTime;
-    return static_cast<std::time_t>(v);
+    timespec value{};
+    return kainote_filetime_to_timespec(ft, &value) ? value.tv_sec : static_cast<std::time_t>(-1);
 }
 struct KainoteHandleBase {
     enum class Kind { File, Event, Thread, Timer, ChangeNotification } kind;
@@ -254,7 +304,8 @@ struct KainoteEventHandle : KainoteHandleBase {
 };
 struct KainoteThreadHandle : KainoteHandleBase {
     std::thread thread;
-    std::atomic<bool> finished{false};
+	// Completion may outlive a closed thread handle.
+    std::shared_ptr<std::atomic<bool>> finished{std::make_shared<std::atomic<bool>>(false)};
     KainoteThreadHandle() : KainoteHandleBase(Kind::Thread) {}
     explicit KainoteThreadHandle(std::thread&& t) : KainoteHandleBase(Kind::Thread), thread(std::move(t)) {}
     ~KainoteThreadHandle() override { if (thread.joinable()) thread.detach(); }
@@ -263,6 +314,8 @@ struct KainoteTimerState {
     std::mutex mutex;
     std::condition_variable cv;
     std::atomic<bool> cancelled{false};
+	// Coalesce callbacks like Win32 timers.
+    std::atomic<bool> callbackPending{false};
 
     bool wait_for_cancel_or_timeout(DWORD milliseconds) {
         if (cancelled.load()) return true;
@@ -291,11 +344,86 @@ struct KainoteTimerHandle : KainoteHandleBase {
 };
 struct KainoteChangeNotificationHandle : KainoteHandleBase {
     int fd{-1};
-    int watch{-1};
-    KainoteChangeNotificationHandle(int inotifyFd, int watchDescriptor)
-        : KainoteHandleBase(Kind::ChangeNotification), fd(inotifyFd), watch(watchDescriptor) {}
+    bool recursive{};
+    uint32_t mask{};
+    std::map<int, std::string> watchPaths;
+    std::set<std::string> watchedPaths;
+
+    KainoteChangeNotificationHandle(int inotifyFd, bool watchRecursively, uint32_t eventMask)
+        : KainoteHandleBase(Kind::ChangeNotification), fd(inotifyFd),
+          recursive(watchRecursively), mask(eventMask) {}
+
+    bool add_directory(const std::filesystem::path& directory) {
+        std::error_code ec;
+        if (!std::filesystem::is_directory(directory, ec)) return false;
+        const std::string normalized = directory.lexically_normal().string();
+        if (!watchedPaths.insert(normalized).second) return true;
+        const int wd = inotify_add_watch(fd, normalized.c_str(), mask | IN_ONLYDIR);
+        if (wd < 0) {
+            watchedPaths.erase(normalized);
+            return false;
+        }
+        auto previous = watchPaths.find(wd);
+        if (previous != watchPaths.end()) watchedPaths.erase(previous->second);
+        watchPaths[wd] = normalized;
+        watchedPaths.insert(normalized);
+        return true;
+    }
+
+    bool add_directory_tree(const std::filesystem::path& root) {
+        bool added = add_directory(root);
+        if (!recursive || !added) return added;
+
+        std::error_code ec;
+        std::filesystem::recursive_directory_iterator iterator(
+            root, std::filesystem::directory_options::skip_permission_denied, ec);
+        const std::filesystem::recursive_directory_iterator end;
+        while (iterator != end) {
+            if (!ec && iterator->is_directory(ec)) add_directory(iterator->path());
+            ec.clear();
+            iterator.increment(ec);
+        }
+        return added;
+    }
+
+    bool consume_events() {
+        alignas(inotify_event) char buffer[64 * 1024];
+        bool consumed = false;
+        while (true) {
+            const ssize_t length = read(fd, buffer, sizeof(buffer));
+            if (length < 0) {
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+                return false;
+            }
+            if (length == 0) break;
+            consumed = true;
+            std::size_t offset = 0;
+            while (offset + sizeof(inotify_event) <= static_cast<std::size_t>(length)) {
+                const auto* event = reinterpret_cast<const inotify_event*>(buffer + offset);
+                auto watched = watchPaths.find(event->wd);
+                if (recursive && watched != watchPaths.end() && event->len &&
+                    (event->mask & IN_ISDIR) &&
+                    (event->mask & (IN_CREATE | IN_MOVED_TO))) {
+                    add_directory_tree(std::filesystem::path(watched->second) / event->name);
+                }
+                if ((event->mask & IN_IGNORED) && watched != watchPaths.end()) {
+                    watchedPaths.erase(watched->second);
+                    watchPaths.erase(watched);
+                }
+                offset += sizeof(inotify_event) + event->len;
+            }
+        }
+        return consumed;
+    }
+
     ~KainoteChangeNotificationHandle() override {
-        if (fd >= 0 && watch >= 0) inotify_rm_watch(fd, watch);
+        if (fd >= 0) {
+            for (const auto& [watch, unused] : watchPaths) {
+                (void)unused;
+                inotify_rm_watch(fd, watch);
+            }
+        }
         if (fd >= 0) close(fd);
     }
 };
@@ -313,12 +441,16 @@ inline HANDLE CreateFileA(const char* path, DWORD access, DWORD, void*, DWORD cr
 inline HANDLE CreateFile(const wchar_t* path, DWORD access, DWORD share, void* sec, DWORD creation, DWORD flags, HANDLE tmpl) { return CreateFileW(path, access, share, sec, creation, flags, tmpl); }
 inline HANDLE CreateFile(const char* path, DWORD access, DWORD share, void* sec, DWORD creation, DWORD flags, HANDLE tmpl) { return CreateFileA(path, access, share, sec, creation, flags, tmpl); }
 inline KainoteHandleBase* kainote_handle(HANDLE h) { return (!h || h == INVALID_HANDLE_VALUE) ? nullptr : reinterpret_cast<KainoteHandleBase*>(h); }
-inline bool GetFileTime(HANDLE h, FILETIME*, FILETIME*, FILETIME* write) {
+inline bool GetFileTime(HANDLE h, FILETIME* creation, FILETIME* access, FILETIME* write) {
     auto* base = kainote_handle(h);
-    if (!base || base->kind != KainoteHandleBase::Kind::File || !write) return false;
+    if (!base || base->kind != KainoteHandleBase::Kind::File) return false;
     FILE* f = static_cast<KainoteFileHandle*>(base)->file;
     int fd=fileno(f); struct stat st{}; if (fstat(fd,&st)!=0) return false;
-    std::uint64_t v=(std::uint64_t)st.st_mtime; write->dwLowDateTime=(DWORD)v; write->dwHighDateTime=(DWORD)(v>>32); return true;
+	// POSIX has no portable creation time; use ctime as the closest value.
+    if (creation && !kainote_timespec_to_filetime(st.st_ctim, creation)) return false;
+    if (access && !kainote_timespec_to_filetime(st.st_atim, access)) return false;
+    if (write && !kainote_timespec_to_filetime(st.st_mtim, write)) return false;
+    return true;
 }
 inline bool CloseHandle(HANDLE h) { auto* base = kainote_handle(h); if (!base) return false; delete base; return true; }
 inline DWORD GetLastError() { return errno; }
@@ -334,22 +466,61 @@ inline void kainote_fill_find_data(const std::filesystem::directory_entry& e, WI
     auto name = kainote_utf8_to_wstring(e.path().filename().string());
     std::wcsncpy(data->cFileName, name.c_str(), MAX_PATH - 1);
     std::error_code ec; auto sz = e.is_regular_file(ec) ? e.file_size(ec) : 0; data->nFileSizeLow = static_cast<DWORD>(sz & 0xffffffffu);
-    auto ft = e.last_write_time(ec); if (!ec) { auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(ft - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now()); auto tt = std::chrono::system_clock::to_time_t(sctp); std::uint64_t v = static_cast<std::uint64_t>(tt); data->ftLastWriteTime.dwLowDateTime = static_cast<DWORD>(v); data->ftLastWriteTime.dwHighDateTime = static_cast<DWORD>(v >> 32); }
+    struct stat metadata{};
+    if (::stat(e.path().c_str(), &metadata) == 0)
+        kainote_timespec_to_filetime(metadata.st_mtim, &data->ftLastWriteTime);
+}
+inline char kainote_ascii_fold(char ch) {
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+}
+inline bool kainote_windows_wildcard_match(const std::string& name, const std::string& pattern) {
+	// Win32 matching is case-insensitive and treats *.* as match-all.
+    if (pattern == "*" || pattern == "*.*") return true;
+    std::size_t namePos = 0;
+    std::size_t patternPos = 0;
+    std::size_t starPos = std::string::npos;
+    std::size_t retryNamePos = 0;
+    while (namePos < name.size()) {
+        if (patternPos < pattern.size() &&
+            (pattern[patternPos] == '?' ||
+             kainote_ascii_fold(pattern[patternPos]) == kainote_ascii_fold(name[namePos]))) {
+            ++namePos;
+            ++patternPos;
+        } else if (patternPos < pattern.size() && pattern[patternPos] == '*') {
+            starPos = patternPos++;
+            retryNamePos = namePos;
+        } else if (starPos != std::string::npos) {
+            patternPos = starPos + 1;
+            namePos = ++retryNamePos;
+        } else {
+            return false;
+        }
+    }
+    while (patternPos < pattern.size() && pattern[patternPos] == '*') ++patternPos;
+    return patternPos == pattern.size();
 }
 inline HANDLE FindFirstFileW(const wchar_t* pattern, WIN32_FIND_DATAW* data) {
-    std::string pat = kainote_normalize_path(pattern); auto star = pat.find('*'); std::filesystem::path dir = star == std::string::npos ? std::filesystem::path(pat).parent_path() : std::filesystem::path(pat.substr(0, star)).parent_path(); std::string prefix = star == std::string::npos ? std::filesystem::path(pat).filename().string() : std::filesystem::path(pat.substr(0, star)).filename().string();
-    if (dir.empty()) dir = "."; std::error_code ec; if (!std::filesystem::exists(dir, ec)) return INVALID_HANDLE_VALUE;
+    const std::filesystem::path searchPath(kainote_normalize_path(pattern));
+    std::filesystem::path dir = searchPath.parent_path();
+    const std::string wildcard = searchPath.filename().string();
+    if (dir.empty()) dir = ".";
+    std::error_code ec;
+    if (!std::filesystem::is_directory(dir, ec)) return INVALID_HANDLE_VALUE;
     auto* h = new KainoteFindHandle();
-    for (auto& e : std::filesystem::directory_iterator(dir, ec)) { if (ec) break; auto n = e.path().filename().string(); if (prefix.empty() || n.rfind(prefix, 0) == 0) h->entries.push_back(e); }
+    for (auto& e : std::filesystem::directory_iterator(dir, ec)) {
+        if (ec) break;
+        if (kainote_windows_wildcard_match(e.path().filename().string(), wildcard))
+            h->entries.push_back(e);
+    }
     if (h->entries.empty()) { delete h; return INVALID_HANDLE_VALUE; }
     kainote_fill_find_data(h->entries[0], data); return static_cast<HANDLE>(h);
 }
 inline HANDLE FindFirstFileA(const char* pattern, WIN32_FIND_DATA* data) { auto w = kainote_utf8_to_wstring(kainote_normalize_path(pattern)); return FindFirstFileW(w.c_str(), data); }
 inline HANDLE FindFirstFileEx(const char* pattern, FINDEX_INFO_LEVELS, WIN32_FIND_DATA* data, int, void*, DWORD) { return FindFirstFileA(pattern, data); }
 inline HANDLE FindFirstFileEx(const wchar_t* pattern, FINDEX_INFO_LEVELS, WIN32_FIND_DATA* data, int, void*, DWORD) { return FindFirstFileW(pattern, data); }
-inline BOOL FindNextFile(HANDLE handle, WIN32_FIND_DATAW* data) { auto* h = static_cast<KainoteFindHandle*>(handle); if (!h) return 0; if (++h->index >= h->entries.size()) return 0; kainote_fill_find_data(h->entries[h->index], data); return 1; }
+inline BOOL FindNextFile(HANDLE handle, WIN32_FIND_DATAW* data) { if (!handle || handle == INVALID_HANDLE_VALUE) return 0; auto* h = static_cast<KainoteFindHandle*>(handle); if (++h->index >= h->entries.size()) return 0; kainote_fill_find_data(h->entries[h->index], data); return 1; }
 inline BOOL FindNextFileW(HANDLE handle, WIN32_FIND_DATAW* data) { return FindNextFile(handle, data); }
-inline BOOL FindClose(HANDLE handle) { auto* h = static_cast<KainoteFindHandle*>(handle); delete h; return 1; }
+inline BOOL FindClose(HANDLE handle) { if (!handle || handle == INVALID_HANDLE_VALUE) return FALSE; auto* h = static_cast<KainoteFindHandle*>(handle); delete h; return TRUE; }
 
 constexpr DWORD ERROR_NO_MORE_FILES = 18;
 constexpr DWORD ERROR_FILE_NOT_FOUND = 2;
@@ -379,12 +550,10 @@ inline BOOL SetFileTime(HANDLE h, const FILETIME*, const FILETIME* access, const
     times[0] = st.st_atim;
     times[1] = st.st_mtim;
     if (access) {
-        times[0].tv_sec = kainote_filetime_to_time_t(access);
-        times[0].tv_nsec = 0;
+        if (!kainote_filetime_to_timespec(access, &times[0])) return FALSE;
     }
     if (write) {
-        times[1].tv_sec = kainote_filetime_to_time_t(write);
-        times[1].tv_nsec = 0;
+        if (!kainote_filetime_to_timespec(write, &times[1])) return FALSE;
     }
     return futimens(fd, times) == 0 ? TRUE : FALSE;
 }
@@ -411,6 +580,7 @@ inline BOOL SystemTimeToTzSpecificLocalTime(const TIME_ZONE_INFORMATION*, const 
     std::tm tm{};
     if (!localtime_r(&t, &tm)) return FALSE;
     kainote_tm_to_system(tm, local);
+    local->wMilliseconds = universal->wMilliseconds;
     return TRUE;
 }
 #define _wfopen kainote_wfopen
@@ -443,10 +613,22 @@ inline BOOL UnhookWindowsHookEx(HHOOK) { return 1; }
 inline LRESULT CallNextHookEx(HHOOK, int, WPARAM, LPARAM) { return 0; }
 inline std::mutex& kainote_window_timer_mutex() { static std::mutex m; return m; }
 inline std::map<std::pair<std::uintptr_t, UINT>, std::unique_ptr<KainoteTimerHandle>>& kainote_window_timers() { static std::map<std::pair<std::uintptr_t, UINT>, std::unique_ptr<KainoteTimerHandle>> timers; return timers; }
-inline void kainote_dispatch_timer_proc(TIMERPROC proc) {
-    if (!proc) return;
-    if (wxTheApp) wxTheApp->CallAfter([proc]() { proc(); });
-    else proc();
+inline void kainote_dispatch_timer_proc(const std::shared_ptr<KainoteTimerState>& state, TIMERPROC proc) {
+    if (!state || !proc || state->cancelled.load()) return;
+    bool expected = false;
+    if (!state->callbackPending.compare_exchange_strong(expected, true)) return;
+    if (wxTheApp) {
+        std::weak_ptr<KainoteTimerState> weakState = state;
+        wxTheApp->CallAfter([weakState, proc]() {
+            auto lockedState = weakState.lock();
+            if (!lockedState || lockedState->cancelled.load()) return;
+            proc();
+            lockedState->callbackPending.store(false);
+        });
+    } else {
+        if (!state->cancelled.load()) proc();
+        state->callbackPending.store(false);
+    }
 }
 inline UINT SetTimer(HWND hwnd, UINT id, UINT elapsed, TIMERPROC proc) {
     static std::atomic<UINT> nextTimerId{1};
@@ -460,7 +642,7 @@ inline UINT SetTimer(HWND hwnd, UINT id, UINT elapsed, TIMERPROC proc) {
         do {
             if (state->wait_for_cancel_or_timeout(elapsed)) break;
             if (state->cancelled.load()) break;
-            kainote_dispatch_timer_proc(proc);
+            kainote_dispatch_timer_proc(state, proc);
         } while (!state->cancelled.load());
     });
 
@@ -552,11 +734,11 @@ inline DWORD WaitForSingleObject(HANDLE h, DWORD ms) {
         auto* th = static_cast<KainoteThreadHandle*>(base);
         if (ms == INFINITE) {
             if (th->thread.joinable()) th->thread.join();
-            th->finished = true;
+            th->finished->store(true);
             return WAIT_OBJECT_0;
         }
         auto start = std::chrono::steady_clock::now();
-        while (!th->finished.load()) {
+        while (!th->finished->load()) {
             if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() >= ms) return WAIT_TIMEOUT;
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
@@ -583,26 +765,99 @@ inline DWORD WaitForSingleObject(HANDLE h, DWORD ms) {
         int result = poll(&pfd, 1, timeout);
         if (result == 0) return WAIT_TIMEOUT;
         if (result < 0) return WAIT_FAILED;
-        char buffer[4096];
-        while (read(change->fd, buffer, sizeof(buffer)) > 0) {}
+        if (!(pfd.revents & POLLIN) || !change->consume_events()) return WAIT_FAILED;
         return WAIT_OBJECT_0;
     }
     return WAIT_FAILED;
 }
 inline DWORD WaitForMultipleObjects(DWORD count, const HANDLE* handles, BOOL waitAll, DWORD ms) {
     if (!handles || !count) return WAIT_FAILED;
-    if (waitAll) {
-        for (DWORD i = 0; i < count; ++i) {
-            DWORD r = WaitForSingleObject(handles[i], ms);
-            if (r != WAIT_OBJECT_0) return r;
+    for (DWORD i = 0; i < count; ++i) {
+        auto* base = kainote_handle(handles[i]);
+        if (!base || (base->kind != KainoteHandleBase::Kind::Thread &&
+                      base->kind != KainoteHandleBase::Kind::Event &&
+                      base->kind != KainoteHandleBase::Kind::ChangeNotification)) {
+            return WAIT_FAILED;
         }
-        return WAIT_OBJECT_0;
+    }
+    if (waitAll) {
+        std::vector<KainoteHandleBase*> bases;
+        std::vector<KainoteEventHandle*> events;
+        bases.reserve(count);
+        events.reserve(count);
+        for (DWORD i = 0; i < count; ++i) {
+            auto* base = kainote_handle(handles[i]);
+            bases.push_back(base);
+            if (base->kind == KainoteHandleBase::Kind::Event)
+                events.push_back(static_cast<KainoteEventHandle*>(base));
+        }
+        std::sort(events.begin(), events.end(), std::less<KainoteEventHandle*>{});
+        events.erase(std::unique(events.begin(), events.end()), events.end());
+
+        const auto start = std::chrono::steady_clock::now();
+        while (true) {
+            std::vector<std::unique_lock<std::mutex>> eventLocks;
+            eventLocks.reserve(events.size());
+            for (auto* event : events) eventLocks.emplace_back(event->mutex);
+
+            bool allReady = true;
+            bool failed = false;
+            for (auto* base : bases) {
+                if (base->kind == KainoteHandleBase::Kind::Event) {
+                    if (!static_cast<KainoteEventHandle*>(base)->signaled) allReady = false;
+                } else if (base->kind == KainoteHandleBase::Kind::Thread) {
+                    if (!static_cast<KainoteThreadHandle*>(base)->finished->load()) allReady = false;
+                } else {
+                    auto* change = static_cast<KainoteChangeNotificationHandle*>(base);
+                    if (change->fd < 0) {
+                        failed = true;
+                        allReady = false;
+                        continue;
+                    }
+                    pollfd descriptor{change->fd, POLLIN, 0};
+                    const int result = poll(&descriptor, 1, 0);
+                    if (result < 0 && errno != EINTR) failed = true;
+                    if (result <= 0 || !(descriptor.revents & POLLIN)) allReady = false;
+                    if (descriptor.revents & (POLLERR | POLLHUP | POLLNVAL)) failed = true;
+                }
+            }
+            if (failed) return WAIT_FAILED;
+
+            if (allReady) {
+				// Consume auto-reset events only after every handle is ready.
+                for (auto* base : bases) {
+                    if (base->kind == KainoteHandleBase::Kind::ChangeNotification &&
+                        !static_cast<KainoteChangeNotificationHandle*>(base)->consume_events()) {
+                        return WAIT_FAILED;
+                    }
+                }
+                for (auto* event : events) {
+                    if (!event->manualReset) event->signaled = false;
+                }
+                eventLocks.clear();
+                for (auto* base : bases) {
+                    if (base->kind == KainoteHandleBase::Kind::Thread) {
+                        auto* thread = static_cast<KainoteThreadHandle*>(base);
+                        if (thread->thread.joinable()) thread->thread.join();
+                    }
+                }
+                return WAIT_OBJECT_0;
+            }
+
+            eventLocks.clear();
+            if (ms != INFINITE &&
+                std::chrono::steady_clock::now() - start >= std::chrono::milliseconds(ms)) {
+                return WAIT_TIMEOUT;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
     }
     auto start = std::chrono::steady_clock::now();
     while (true) {
         for (DWORD i = 0; i < count; ++i) {
             DWORD r = WaitForSingleObject(handles[i], 0);
             if (r == WAIT_OBJECT_0) return WAIT_OBJECT_0 + i;
+            if (r == WAIT_FAILED) return WAIT_FAILED;
         }
         if (ms != INFINITE && std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() >= ms) return WAIT_TIMEOUT;
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -616,7 +871,8 @@ inline uintptr_t _beginthreadex(void*, unsigned, KainoteThreadProc proc, void* d
     if (!proc) return 0;
     if (threadid) *threadid = GetCurrentThreadId();
     auto* handle = new KainoteThreadHandle();
-    handle->thread = std::thread([proc, data, handle]() { proc(data); handle->finished = true; });
+    auto finished = handle->finished;
+    handle->thread = std::thread([proc, data, finished]() { proc(data); finished->store(true); });
     return reinterpret_cast<uintptr_t>(handle);
 }
 inline void Sleep(DWORD ms) { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
@@ -881,26 +1137,118 @@ inline DWORD GetFontData(HDC dc, DWORD, DWORD offset, void* buffer, DWORD length
     input.read(reinterpret_cast<char*>(buffer), toRead);
     return static_cast<DWORD>(input.gcount());
 }
-inline HANDLE FindFirstChangeNotification(const wchar_t* path, BOOL, DWORD) {
-    if (!path) return INVALID_HANDLE_VALUE;
-    std::string normalized = kainote_normalize_path(path);
+inline HANDLE kainote_create_change_notification(const std::vector<std::string>& paths, BOOL recursive) {
     int fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
     if (fd < 0) return INVALID_HANDLE_VALUE;
-    const uint32_t mask = IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO | IN_CLOSE_WRITE | IN_ATTRIB;
-    int wd = inotify_add_watch(fd, normalized.c_str(), mask);
-    if (wd < 0) {
-        close(fd);
+    const uint32_t mask = IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO |
+                          IN_CLOSE_WRITE | IN_ATTRIB | IN_DELETE_SELF | IN_MOVE_SELF;
+    auto* handle = new KainoteChangeNotificationHandle(fd, recursive != FALSE, mask);
+    for (const auto& path : paths) {
+        if (!path.empty()) handle->add_directory_tree(std::filesystem::path(path));
+    }
+    if (handle->watchPaths.empty()) {
+        delete handle;
         return INVALID_HANDLE_VALUE;
     }
-    return reinterpret_cast<HANDLE>(new KainoteChangeNotificationHandle(fd, wd));
+    return reinterpret_cast<HANDLE>(handle);
+}
+inline HANDLE FindFirstChangeNotification(const wchar_t* path, BOOL recursive, DWORD) {
+    if (!path) return INVALID_HANDLE_VALUE;
+    return kainote_create_change_notification({kainote_normalize_path(path)}, recursive);
+}
+inline HANDLE kainote_find_first_change_notifications(const std::vector<std::wstring>& paths, BOOL recursive, DWORD) {
+    std::vector<std::string> normalized;
+    normalized.reserve(paths.size());
+    for (const auto& path : paths) normalized.push_back(kainote_normalize_path(path.c_str()));
+    return kainote_create_change_notification(normalized, recursive);
+}
+inline std::vector<std::wstring> kainote_linux_font_directories() {
+    std::vector<std::wstring> directories;
+    if (!FcInit()) return directories;
+    FcConfig* config = FcConfigGetCurrent();
+    if (!config) return directories;
+    FcStrList* list = FcConfigGetFontDirs(config);
+    if (!list) return directories;
+    while (FcChar8* directory = FcStrListNext(list)) {
+		try {
+			directories.push_back(kainote_utf8_to_wstring(
+				reinterpret_cast<const char*>(directory)));
+		} catch (const std::range_error&) {
+		}
+    }
+    FcStrListDone(list);
+    std::sort(directories.begin(), directories.end());
+    directories.erase(std::unique(directories.begin(), directories.end()), directories.end());
+    return directories;
 }
 inline BOOL FindNextChangeNotification(HANDLE h) {
     auto* base = kainote_handle(h);
     return base && base->kind == KainoteHandleBase::Kind::ChangeNotification ? TRUE : FALSE;
 }
 inline BOOL FindCloseChangeNotification(HANDLE h) { return CloseHandle(h) ? TRUE : FALSE; }
-inline int AddFontResourceExW(const wchar_t* path, DWORD, void*) { if (!path || !FcInit()) return 0; std::string p = kainote_normalize_path(path); FcConfig* config = FcConfigGetCurrent(); if (!config) return 0; if (!FcConfigAppFontAddFile(config, reinterpret_cast<const FcChar8*>(p.c_str()))) return 0; FcConfigBuildFonts(config); return 1; }
-inline BOOL RemoveFontResourceExW(const wchar_t*, DWORD, void*) { if (!FcInit()) return FALSE; FcConfig* config = FcConfigGetCurrent(); if (!config) return FALSE; FcConfigAppFontClear(config); FcConfigBuildFonts(config); return TRUE; }
+inline std::mutex& kainote_app_font_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+inline std::map<std::string, std::size_t>& kainote_app_font_references() {
+    static std::map<std::string, std::size_t> references;
+    return references;
+}
+inline bool kainote_rebuild_app_fonts(FcConfig* config) {
+    FcConfigAppFontClear(config);
+    bool addedAll = true;
+    for (const auto& [path, references] : kainote_app_font_references()) {
+        (void)references;
+        if (!FcConfigAppFontAddFile(config,
+                reinterpret_cast<const FcChar8*>(path.c_str()))) {
+            addedAll = false;
+        }
+    }
+    return FcConfigBuildFonts(config) != FcFalse && addedAll;
+}
+inline int AddFontResourceExW(const wchar_t* path, DWORD, void*) {
+    if (!path || !FcInit()) return 0;
+    const std::string normalized = kainote_normalize_path(path);
+    FcConfig* config = FcConfigGetCurrent();
+    if (!config) return 0;
+    std::lock_guard<std::mutex> lock(kainote_app_font_mutex());
+    auto& references = kainote_app_font_references();
+    auto existing = references.find(normalized);
+    if (existing != references.end()) {
+        ++existing->second;
+        return 1;
+    }
+    if (!FcConfigAppFontAddFile(config,
+            reinterpret_cast<const FcChar8*>(normalized.c_str()))) {
+        return 0;
+    }
+    references.emplace(normalized, 1);
+    if (FcConfigBuildFonts(config) == FcFalse) {
+        references.erase(normalized);
+        kainote_rebuild_app_fonts(config);
+        return 0;
+    }
+    return 1;
+}
+inline BOOL RemoveFontResourceExW(const wchar_t* path, DWORD, void*) {
+    if (!path || !FcInit()) return FALSE;
+    const std::string normalized = kainote_normalize_path(path);
+    FcConfig* config = FcConfigGetCurrent();
+    if (!config) return FALSE;
+    std::lock_guard<std::mutex> lock(kainote_app_font_mutex());
+    auto& references = kainote_app_font_references();
+    auto existing = references.find(normalized);
+    if (existing == references.end()) return FALSE;
+    if (existing->second > 1) {
+        --existing->second;
+        return TRUE;
+    }
+    references.erase(existing);
+    if (kainote_rebuild_app_fonts(config)) return TRUE;
+    references.emplace(normalized, 1);
+    kainote_rebuild_app_fonts(config);
+    return FALSE;
+}
 inline LRESULT SendMessage(HWND, UINT, WPARAM, LPARAM) { return 0; }
 inline HICON GetHiconOf(...) { return nullptr; }
 inline HRESULT CoInitialize(void*) { return 0; }
@@ -916,11 +1264,10 @@ constexpr int SW_MINIMIZE = 6;
 constexpr DWORD SEE_MASK_FLAG_NO_UI = 0x400;
 inline BOOL ShellExecuteEx(SHELLEXECUTEINFO* sei) {
     if (!sei || !sei->lpFile) return FALSE;
-    std::string target = kainote_wstring_to_utf8(sei->lpFile);
-    std::string command = "xdg-open \"";
-    for (char ch : target) { if (ch == '"' || ch == '\\') command.push_back('\\'); command.push_back(ch); }
-    command += "\" >/dev/null 2>&1 &";
-    return std::system(command.c_str()) == 0;
+    const wxString target(sei->lpFile);
+    if (target.StartsWith(L"http://") || target.StartsWith(L"https://"))
+        return wxLaunchDefaultBrowser(target) ? TRUE : FALSE;
+    return wxLaunchDefaultApplication(target) ? TRUE : FALSE;
 }
 struct SHFILEOPSTRUCT { HWND hwnd{}; UINT wFunc{}; LPCWSTR pFrom{}; LPCWSTR pTo{}; unsigned short fFlags{}; };
 constexpr UINT FO_DELETE = 0x0003;
@@ -1130,10 +1477,60 @@ inline void SHChangeNotify(long, unsigned, const void*, const void*) {}
 inline UINT RegisterWindowMessage(LPCWSTR) { static UINT next = 0xC000; return next++; }
 struct STARTUPINFO { DWORD cb{}; };
 struct PROCESS_INFORMATION { HANDLE hProcess{}; HANDLE hThread{}; DWORD dwProcessId{}; DWORD dwThreadId{}; };
-inline BOOL CreateProcessW(LPCWSTR, LPWSTR commandLine, void*, void*, BOOL, DWORD, void*, LPCWSTR, STARTUPINFO*, PROCESS_INFORMATION*) {
-    if (!commandLine) return FALSE;
-    std::string command = kainote_wstring_to_utf8(commandLine);
-    return std::system(command.c_str()) == 0;
+inline std::vector<std::wstring> kainote_parse_windows_command_line(LPCWSTR commandLine) {
+    std::vector<std::wstring> arguments;
+    if (!commandLine) return arguments;
+    const wchar_t* cursor = commandLine;
+    while (*cursor) {
+        while (*cursor && std::iswspace(*cursor)) ++cursor;
+        if (!*cursor) break;
+        std::wstring argument;
+        bool quoted = false;
+        while (*cursor && (quoted || !std::iswspace(*cursor))) {
+            if (*cursor == L'\\') {
+                std::size_t slashCount = 0;
+                while (*cursor == L'\\') {
+                    ++slashCount;
+                    ++cursor;
+                }
+                if (*cursor == L'"') {
+                    argument.append(slashCount / 2, L'\\');
+                    if (slashCount % 2) {
+                        argument.push_back(L'"');
+                        ++cursor;
+                    } else {
+                        quoted = !quoted;
+                        ++cursor;
+                    }
+                } else {
+                    argument.append(slashCount, L'\\');
+                }
+            } else if (*cursor == L'"') {
+                quoted = !quoted;
+                ++cursor;
+            } else {
+                argument.push_back(*cursor++);
+            }
+        }
+        arguments.push_back(std::move(argument));
+    }
+    return arguments;
+}
+inline BOOL CreateProcessW(LPCWSTR applicationName, LPWSTR commandLine, void*, void*, BOOL, DWORD, void*, LPCWSTR, STARTUPINFO*, PROCESS_INFORMATION* processInfo) {
+    auto arguments = kainote_parse_windows_command_line(commandLine);
+    if (arguments.empty() && applicationName) arguments.emplace_back(applicationName);
+    if (arguments.empty()) return FALSE;
+    std::vector<const wchar_t*> argv;
+    argv.reserve(arguments.size() + 1);
+    for (const auto& argument : arguments) argv.push_back(argument.c_str());
+    argv.push_back(nullptr);
+    const long pid = wxExecute(argv.data(), wxEXEC_ASYNC);
+    if (pid == 0) return FALSE;
+    if (processInfo) {
+        *processInfo = PROCESS_INFORMATION{};
+        processInfo->dwProcessId = static_cast<DWORD>(pid);
+    }
+    return TRUE;
 }
 constexpr const wchar_t* RT_RCDATA = L"RCDATA";
 inline HRSRC FindResource(void*, const wchar_t*, const wchar_t*) { return nullptr; }

--- a/Kainote/styles.h
+++ b/Kainote/styles.h
@@ -41,8 +41,7 @@ class AssColor
 		r = red;
 		g = green;
 		b = blue;
-		if (alpha > -1)
-			a = alpha;
+		a = alpha > -1 ? alpha : 0;
 	}
 	~AssColor();
 	bool operator == (const AssColor &col){ return (a == col.a && r == col.r && g == col.g && b == col.b); }

--- a/Locale/ko_KR.po
+++ b/Locale/ko_KR.po
@@ -3924,8 +3924,7 @@ msgstr ""
 msgid ""
 "Nie można zamienić \"%s\" na \"%s\", wykorzystując regułę \"%s\" w linii %i."
 msgstr ""
-"\"%i\"줄에서 \"%s\"규칙을 사용하여 \"%s\"을(를) \"%s\"(으)로 바꿀 수 없습니"
-"다."
+"\"%s\"을(를) \"%s\"(으)로 바꿀 수 없습니다. 규칙: \"%s\", 줄: %i."
 
 #: MisspellReplacer.cpp:713
 msgid "Usuwanie spacji przed przecinkiem bądź kropką"

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ The executable is written under the repository's Visual Studio output folders, t
 
 ### Linux build
 
-The Linux build uses CMake and system packages. It has been verified on an Ubuntu/Debian-style environment with GCC, wxGTK 3.2, Lua 5.1, FFMS2, FFmpeg, libass, Hunspell, uchardet, libcurl, ICU, Boost, GStreamer 1.x, and OpenGL development packages.
+The Linux build uses CMake and system packages. It has been verified on an Ubuntu/Debian-style environment with GCC, wxGTK 3.2, LuaJIT 2.1 (Lua 5.1-compatible), FFMS2, FFmpeg, libass, Hunspell, uchardet, libcurl, ICU, Boost, GStreamer 1.x, and OpenGL development packages.
 
 #### 1. Install dependencies on Ubuntu/Debian
 
@@ -375,14 +375,17 @@ sudo apt update
 sudo apt install --no-install-recommends -y \
   build-essential \
   cmake \
+  gzip \
+  tar \
   git \
   pkg-config \
   libwxgtk3.2-dev \
   libwxgtk-gl3.2-dev \
   libass-dev \
   libffms2-dev \
-  liblua5.1-0-dev \
+  libluajit-5.1-dev \
   libhunspell-dev \
+  hunspell-en-us \
   libuchardet-dev \
   libcurl4-openssl-dev \
   libicu-dev \
@@ -399,7 +402,8 @@ sudo apt install --no-install-recommends -y \
   libgstreamer-plugins-base1.0-dev \
   gstreamer1.0-plugins-base \
   gstreamer1.0-plugins-good \
-  gstreamer1.0-pulseaudio
+  gstreamer1.0-pulseaudio \
+  gettext
 ```
 
 GStreamer backs both video and audio playback on Linux, so its runtime plugins
@@ -420,13 +424,16 @@ sudo apt install --no-install-recommends -y xvfb
 The exact package names vary by distribution. Install the equivalent development packages for:
 
 - C and C++ compiler toolchain (`gcc`, `g++`, `make`)
-- CMake
+- CMake 3.21 or newer
+- GNU tar and gzip (used by the reproducible Linux archive target)
 - pkg-config
 - wxWidgets/wxGTK 3.x with core, base, adv, aui, html, xml, gl, and stc components
 - libass
 - FFMS2
-- Lua 5.1 development headers and library
+- LuaJIT 2.1 development headers and library (the `luajit` pkg-config module)
 - Hunspell
+- A Hunspell dictionary (the runtime copy step looks for `en_US.aff` and `en_US.dic`)
+- GNU gettext (`msgfmt`) for compiling translations
 - uchardet
 - libcurl
 - ICU (`icu-uc` and `icu-i18n` pkg-config modules)
@@ -442,24 +449,24 @@ For Fedora-like systems, the package set is approximately:
 
 ```bash
 sudo dnf install \
-  gcc gcc-c++ make cmake git pkgconf-pkg-config \
+  gcc gcc-c++ make cmake gzip tar git pkgconf-pkg-config \
   wxGTK-devel wxGTK-gl wxGTK-media \
-  libass-devel ffms2-devel lua-devel hunspell-devel uchardet-devel \
+  libass-devel ffms2-devel luajit-devel hunspell-devel hunspell-en-US uchardet-devel \
   libcurl-devel libicu-devel boost-devel ffmpeg-devel mesa-libGL-devel gtk3-devel \
   gstreamer1-devel gstreamer1-plugins-base-devel \
-  gstreamer1-plugins-base gstreamer1-plugins-good
+  gstreamer1-plugins-base gstreamer1-plugins-good gettext
 ```
 
 For Arch-like systems, the package set is approximately:
 
 ```bash
 sudo pacman -S --needed \
-  base-devel cmake git pkgconf wxwidgets-gtk3 libass ffms2 lua51 \
-  hunspell uchardet curl icu boost ffmpeg mesa gtk3 \
-  gstreamer gst-plugins-base gst-plugins-good
+  base-devel cmake gzip tar git pkgconf wxwidgets-gtk3 libass ffms2 luajit \
+  hunspell hunspell-en_us uchardet curl icu boost ffmpeg mesa gtk3 \
+  gstreamer gst-plugins-base gst-plugins-good gettext
 ```
 
-If your distribution only provides Lua 5.4 as `lua`, install the separate Lua 5.1 development package. The CMake file intentionally checks for `lua5.1` because Kainote uses Lua 5.1 APIs such as `lua_getfenv`, `lua_objlen`, and `luaL_register`.
+Kainote requires LuaJIT rather than the standard Lua interpreter: its Automation subsystem uses LuaJIT's FFI as well as Lua 5.1 APIs. The CMake configuration therefore checks for the `luajit` pkg-config module.
 
 #### 3. Verify dependency discovery
 
@@ -469,7 +476,7 @@ Before configuring Kainote, confirm that pkg-config can find the required librar
 pkg-config --modversion \
   libass \
   ffms2 \
-  lua5.1 \
+  luajit \
   hunspell \
   uchardet \
   libcurl \
@@ -505,6 +512,21 @@ The executable is created at:
 ```text
 build-linux/kainote
 ```
+
+To create a clean Linux runtime archive after building:
+
+```bash
+cmake --build build-linux --target kainote_linux_package
+```
+
+The archive and its SHA-256 file are written under `build-linux/dist/`. The
+package target uses an explicit allowlist: it includes the executable,
+manifest-recorded runtime libraries, freshly compiled translations, bitmap
+resources, the project license, and the configured English dictionary when one
+is available. It deliberately excludes CMake internals and any Config,
+Automation, or Themes files created by local runs. Host graphics/windowing
+libraries, codec libraries excluded for licensing reasons, and GStreamer
+plugins remain system requirements; this archive is not a universal AppImage.
 
 #### 5. Run Kainote
 
@@ -552,10 +574,9 @@ Media backends (Windows uses DirectShow / DirectSound / Direct3D):
 - Audio plays through **GStreamer** (`appsrc → audioconvert → audioresample →
   autoaudiosink`); the playback position is tracked on a wall-clock model. There
   is no DirectSound path.
-- Because Linux builds may bundle a relocated `libgstreamer`, the plugin search
-  path is pinned at build time (`pkg-config --variable=pluginsdir gstreamer-1.0`)
-  and exported before `gst_init`, so the system GStreamer plugins are found at
-  runtime. The base and good plugin sets (and an audio sink) must be installed.
+- GStreamer discovers plugins from the runtime system registry and standard
+  plugin paths. The base and good plugin sets (and an audio sink) must be
+  installed on the machine that runs Kainote.
 
 Other Linux differences:
 

--- a/cmake/CopyLocaleCatalogs.cmake
+++ b/cmake/CopyLocaleCatalogs.cmake
@@ -20,7 +20,7 @@ foreach(po_file IN LISTS KAINOTE_PO_FILES)
         RESULT_VARIABLE msgfmt_result
     )
     if(msgfmt_result)
-        message(WARNING "msgfmt failed for ${po_file} (exit ${msgfmt_result})")
+        message(FATAL_ERROR "msgfmt failed for ${po_file} (exit ${msgfmt_result})")
     else()
         file(COPY_FILE "${locale_messages_dir}/${locale_name}.mo"
                        "${RUNTIME_LOCALE_DIR}/${locale_name}.mo" ONLY_IF_DIFFERENT)

--- a/cmake/CopyRuntimeDependencies.cmake
+++ b/cmake/CopyRuntimeDependencies.cmake
@@ -2,6 +2,33 @@ if(NOT DEFINED KAINOTE_EXE OR NOT DEFINED RUNTIME_DIR)
     message(FATAL_ERROR "KAINOTE_EXE and RUNTIME_DIR are required")
 endif()
 
+# Remove previously manifested libraries before rescanning $ORIGIN.
+set(runtime_manifest "${RUNTIME_DIR}/.kainote-runtime-dependencies")
+if(EXISTS "${runtime_manifest}")
+    file(STRINGS "${runtime_manifest}" previous_runtime_deps)
+    foreach(dep_name IN LISTS previous_runtime_deps)
+        if(dep_name MATCHES "^lib[^/\\\\]+\\.so(\\..*)?$")
+            file(REMOVE "${RUNTIME_DIR}/${dep_name}")
+        else()
+            message(WARNING "Ignoring invalid runtime manifest entry: ${dep_name}")
+        endif()
+    endforeach()
+elseif(DEFINED KAINOTE_BUILD_DIR)
+    # Clean pre-manifest files only in the verified CMake build directory.
+    file(REAL_PATH "${RUNTIME_DIR}" runtime_dir_real)
+    file(REAL_PATH "${KAINOTE_BUILD_DIR}" build_dir_real)
+    if(runtime_dir_real STREQUAL build_dir_real AND
+       EXISTS "${build_dir_real}/CMakeCache.txt")
+        file(GLOB legacy_runtime_deps LIST_DIRECTORIES FALSE
+            "${RUNTIME_DIR}/lib*.so" "${RUNTIME_DIR}/lib*.so.*")
+        if(legacy_runtime_deps)
+            list(LENGTH legacy_runtime_deps legacy_count)
+            file(REMOVE ${legacy_runtime_deps})
+            message(STATUS "Removed ${legacy_count} legacy bundled runtime dependencies before dependency discovery")
+        endif()
+    endif()
+endif()
+
 file(GET_RUNTIME_DEPENDENCIES
     EXECUTABLES "${KAINOTE_EXE}"
     RESOLVED_DEPENDENCIES_VAR resolved_deps
@@ -9,7 +36,7 @@ file(GET_RUNTIME_DEPENDENCIES
 )
 
 if(unresolved_deps)
-    message(WARNING "Unresolved runtime dependencies: ${unresolved_deps}")
+    message(FATAL_ERROR "Unresolved runtime dependencies: ${unresolved_deps}")
 endif()
 
 # Bundle only the application's own version-sensitive libraries (wxWidgets, ICU,
@@ -35,6 +62,7 @@ set(system_dep_regex
 )
 
 set(copied_count 0)
+set(copied_names)
 foreach(dep IN LISTS resolved_deps)
     get_filename_component(dep_name "${dep}" NAME)
     if(NOT dep_name MATCHES "${system_dep_regex}")
@@ -47,8 +75,15 @@ foreach(dep IN LISTS resolved_deps)
         if(NOT copy_result EQUAL 0)
             message(FATAL_ERROR "Failed to copy runtime dependency ${dep}")
         endif()
+        list(APPEND copied_names "${dep_name}")
         math(EXPR copied_count "${copied_count} + 1")
     endif()
 endforeach()
+
+list(REMOVE_DUPLICATES copied_names)
+list(SORT copied_names)
+string(REPLACE ";" "\n" runtime_manifest_contents "${copied_names}")
+file(WRITE "${runtime_manifest}.tmp" "${runtime_manifest_contents}\n")
+file(RENAME "${runtime_manifest}.tmp" "${runtime_manifest}")
 
 message(STATUS "Copied ${copied_count} bundled runtime dependencies to ${RUNTIME_DIR}")

--- a/cmake/GenGitParams.cmake
+++ b/cmake/GenGitParams.cmake
@@ -21,7 +21,7 @@ else()
     if(GIT_BRANCH STREQUAL "")
         set(GIT_BRANCH "unknown")
     endif()
-    set(CONTENT "#pragma once\n#define _KAI_QUOTE(x) #x\n#define ADD_QUOTES(x) _KAI_QUOTE(x)\n#define GIT_BRANCH ${GIT_BRANCH}\n#define GIT_CUR_COMMIT ${GIT_COMMIT}\n")
+    set(CONTENT "#pragma once\n#define GIT_BRANCH ${GIT_BRANCH}\n#define GIT_CUR_COMMIT ${GIT_COMMIT}\n")
 endif()
 
 set(OUT "${SRC}/Kainote/gitparams.h")

--- a/cmake/PackageLinuxRuntime.cmake
+++ b/cmake/PackageLinuxRuntime.cmake
@@ -1,0 +1,216 @@
+foreach(required_var IN ITEMS
+        KAINOTE_EXE RUNTIME_DIR SOURCE_DIR BINARY_DIR STAGING_PARENT
+        PACKAGE_BASENAME ARCHIVE_PATH MSGFMT_EXECUTABLE TAR_EXECUTABLE
+        GZIP_EXECUTABLE)
+    if(NOT DEFINED ${required_var} OR "${${required_var}}" STREQUAL "")
+        message(FATAL_ERROR "${required_var} is required")
+    endif()
+endforeach()
+
+if(NOT PACKAGE_BASENAME MATCHES "^[A-Za-z0-9][A-Za-z0-9._+-]*$")
+    message(FATAL_ERROR
+        "PACKAGE_BASENAME must be a single safe path component: "
+        "${PACKAGE_BASENAME}")
+endif()
+if(NOT IS_DIRECTORY "${BINARY_DIR}" OR
+   NOT EXISTS "${BINARY_DIR}/CMakeCache.txt")
+    message(FATAL_ERROR "BINARY_DIR is not a configured CMake build tree: ${BINARY_DIR}")
+endif()
+if(NOT IS_DIRECTORY "${STAGING_PARENT}")
+    message(FATAL_ERROR "Package staging parent does not exist: ${STAGING_PARENT}")
+endif()
+
+file(REAL_PATH "${BINARY_DIR}" binary_dir_abs)
+file(REAL_PATH "${STAGING_PARENT}" staging_parent_abs)
+file(REAL_PATH "${binary_dir_abs}/package-stage" expected_staging_parent_abs)
+if(NOT staging_parent_abs STREQUAL expected_staging_parent_abs)
+    message(FATAL_ERROR
+        "Package staging must be the dedicated build-tree package-stage directory: "
+        "${staging_parent_abs}")
+endif()
+file(TO_CMAKE_PATH "${binary_dir_abs}/" binary_dir_prefix)
+file(TO_CMAKE_PATH "${staging_parent_abs}/" staging_parent_prefix)
+string(FIND "${staging_parent_prefix}" "${binary_dir_prefix}" staging_prefix_pos)
+if(NOT staging_prefix_pos EQUAL 0)
+    message(FATAL_ERROR
+        "Refusing to clean package staging directory outside the CMake build tree: "
+        "${staging_parent_abs}")
+endif()
+
+if(NOT EXISTS "${KAINOTE_EXE}")
+    message(FATAL_ERROR "Kainote executable is missing: ${KAINOTE_EXE}")
+endif()
+
+set(runtime_manifest "${RUNTIME_DIR}/.kainote-runtime-dependencies")
+if(NOT EXISTS "${runtime_manifest}")
+    message(FATAL_ERROR
+        "Runtime dependency manifest is missing. Build the kainote target first: "
+        "${runtime_manifest}")
+endif()
+
+set(package_root "${staging_parent_abs}/${PACKAGE_BASENAME}")
+file(REMOVE_RECURSE "${package_root}")
+file(MAKE_DIRECTORY "${package_root}" "${package_root}/Kainote")
+
+file(COPY_FILE "${KAINOTE_EXE}" "${package_root}/kainote")
+
+# Copy only manifest-listed runtime libraries.
+file(STRINGS "${runtime_manifest}" runtime_deps)
+if(NOT runtime_deps)
+    message(FATAL_ERROR "Runtime dependency manifest is empty: ${runtime_manifest}")
+endif()
+foreach(dep_name IN LISTS runtime_deps)
+    if(NOT dep_name MATCHES "^lib[^/\\\\]+\\.so(\\..*)?$")
+        message(FATAL_ERROR "Invalid runtime dependency manifest entry: ${dep_name}")
+    endif()
+    if(NOT EXISTS "${RUNTIME_DIR}/${dep_name}")
+        message(FATAL_ERROR "Manifest-listed runtime dependency is missing: ${dep_name}")
+    endif()
+    file(COPY_FILE
+        "${RUNTIME_DIR}/${dep_name}"
+        "${package_root}/${dep_name}")
+endforeach()
+file(COPY_FILE "${runtime_manifest}"
+               "${package_root}/.kainote-runtime-dependencies")
+
+if(NOT EXISTS "${SOURCE_DIR}/Kainote/resource.rc" OR
+   NOT IS_DIRECTORY "${SOURCE_DIR}/Kainote/Bitmaps")
+    message(FATAL_ERROR "Required Linux bitmap resources are missing from the source tree")
+endif()
+file(COPY_FILE "${SOURCE_DIR}/Kainote/resource.rc"
+               "${package_root}/Kainote/resource.rc")
+file(COPY "${SOURCE_DIR}/Kainote/Bitmaps"
+     DESTINATION "${package_root}/Kainote")
+
+# Recompile catalogs instead of using stale runtime copies.
+set(SOURCE_LOCALE_DIR "${SOURCE_DIR}/Locale")
+set(RUNTIME_LOCALE_DIR "${package_root}/Locale")
+include("${SOURCE_DIR}/cmake/CopyLocaleCatalogs.cmake")
+
+# Prefer the repository dictionary, then the configured en_US pair.
+if(IS_DIRECTORY "${SOURCE_DIR}/Dictionary")
+    file(COPY "${SOURCE_DIR}/Dictionary/"
+         DESTINATION "${package_root}/Dictionary")
+elseif(DEFINED SYSTEM_DICTIONARY_DIR AND
+       EXISTS "${SYSTEM_DICTIONARY_DIR}/en_US.aff" AND
+       EXISTS "${SYSTEM_DICTIONARY_DIR}/en_US.dic")
+    file(MAKE_DIRECTORY "${package_root}/Dictionary")
+    file(COPY_FILE "${SYSTEM_DICTIONARY_DIR}/en_US.aff"
+                   "${package_root}/Dictionary/en_US.aff")
+    file(COPY_FILE "${SYSTEM_DICTIONARY_DIR}/en_US.dic"
+                   "${package_root}/Dictionary/en_US.dic")
+else()
+    message(WARNING
+        "Packaging without an en_US dictionary; the spell checker will have no "
+        "default dictionary")
+endif()
+
+if(EXISTS "${SOURCE_DIR}/LICENSE")
+    file(COPY_FILE "${SOURCE_DIR}/LICENSE" "${package_root}/LICENSE")
+endif()
+
+# Normalize modes for reproducibility.
+file(GLOB_RECURSE package_entries
+    LIST_DIRECTORIES TRUE
+    "${package_root}/*")
+foreach(package_entry IN LISTS package_entries)
+    if(IS_DIRECTORY "${package_entry}")
+        file(CHMOD "${package_entry}"
+            PERMISSIONS
+                OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                GROUP_READ GROUP_EXECUTE
+                WORLD_READ WORLD_EXECUTE)
+    else()
+        file(CHMOD "${package_entry}"
+            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+    endif()
+endforeach()
+file(CHMOD "${package_root}"
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE)
+file(CHMOD "${package_root}/kainote"
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE)
+
+# Hash every staged file.
+file(GLOB_RECURSE package_files
+    LIST_DIRECTORIES FALSE
+    RELATIVE "${package_root}"
+    "${package_root}/*")
+list(SORT package_files)
+set(checksums "")
+foreach(relative_file IN LISTS package_files)
+    file(SHA256 "${package_root}/${relative_file}" file_hash)
+    string(APPEND checksums "${file_hash}  ${relative_file}\n")
+endforeach()
+file(WRITE "${package_root}/SHA256SUMS" "${checksums}")
+file(CHMOD "${package_root}/SHA256SUMS"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+get_filename_component(archive_path_abs "${ARCHIVE_PATH}" ABSOLUTE)
+file(TO_CMAKE_PATH "${archive_path_abs}" archive_path_normalized)
+set(expected_archive_path
+    "${binary_dir_abs}/dist/${PACKAGE_BASENAME}.tar.gz")
+file(TO_CMAKE_PATH "${expected_archive_path}" expected_archive_normalized)
+string(FIND "${archive_path_normalized}" "${binary_dir_prefix}" archive_path_prefix_pos)
+if(NOT archive_path_prefix_pos EQUAL 0 OR
+   NOT archive_path_normalized STREQUAL expected_archive_normalized)
+    message(FATAL_ERROR
+        "Archive path must be a .tar.gz inside the CMake build tree: "
+        "${ARCHIVE_PATH}")
+endif()
+set(ARCHIVE_PATH "${archive_path_abs}")
+get_filename_component(archive_dir "${ARCHIVE_PATH}" DIRECTORY)
+file(MAKE_DIRECTORY "${archive_dir}")
+file(REAL_PATH "${archive_dir}" archive_dir_abs)
+file(TO_CMAKE_PATH "${archive_dir_abs}/" archive_dir_prefix)
+string(FIND "${archive_dir_prefix}" "${binary_dir_prefix}" archive_prefix_pos)
+if(NOT archive_prefix_pos EQUAL 0)
+    message(FATAL_ERROR
+        "Archive path must be a .tar.gz inside the CMake build tree: "
+        "${ARCHIVE_PATH}")
+endif()
+set(uncompressed_archive "${ARCHIVE_PATH}.uncompressed")
+file(REMOVE
+    "${ARCHIVE_PATH}"
+    "${ARCHIVE_PATH}.sha256"
+    "${uncompressed_archive}")
+
+# Normalize tar metadata and omit gzip timestamps.
+execute_process(
+    COMMAND "${TAR_EXECUTABLE}"
+            --sort=name
+            --mtime=@0
+            --owner=0
+            --group=0
+            --numeric-owner
+            --format=gnu
+            -cf "${uncompressed_archive}"
+            "${PACKAGE_BASENAME}"
+    WORKING_DIRECTORY "${staging_parent_abs}"
+    RESULT_VARIABLE tar_result
+)
+if(NOT tar_result EQUAL 0)
+    file(REMOVE "${uncompressed_archive}")
+    message(FATAL_ERROR "tar failed while creating ${uncompressed_archive}")
+endif()
+execute_process(
+    COMMAND "${GZIP_EXECUTABLE}" -n -9 -c "${uncompressed_archive}"
+    OUTPUT_FILE "${ARCHIVE_PATH}"
+    RESULT_VARIABLE gzip_result
+)
+file(REMOVE "${uncompressed_archive}")
+if(NOT gzip_result EQUAL 0)
+    file(REMOVE "${ARCHIVE_PATH}")
+    message(FATAL_ERROR "gzip failed while creating ${ARCHIVE_PATH}")
+endif()
+file(SHA256 "${ARCHIVE_PATH}" archive_hash)
+get_filename_component(archive_name "${ARCHIVE_PATH}" NAME)
+file(WRITE "${ARCHIVE_PATH}.sha256" "${archive_hash}  ${archive_name}\n")
+
+message(STATUS "Created ${ARCHIVE_PATH}")
+message(STATUS "SHA-256 ${archive_hash}")


### PR DESCRIPTION
## Summary

- harden the Linux compatibility layer, filesystem watching, process handling, and file-time behavior
- fix lifetime, bounds, text-conversion, font, media, and worker-thread defects found during the audit
- remove the Linux `-fpermissive` dependency and correct the Korean format placeholders
- add documented, reproducible Linux runtime packaging with an explicit dependency allowlist

## Validation

- GCC Release build
- Clang 22 ASan and UBSan full build plus GUI smoke test
- `ldd -r build-linux/kainote` with no missing libraries or unresolved symbols
- all 13 locale catalogs checked with `msgfmt --check`
- package target run twice with identical SHA-256: `1d8943542d717953a37b68462232e64c4e15184da7b9ac0481a2368adb4de39e`
- `git diff --check`

The package emits an expected warning on this host because no en_US Hunspell dictionary is installed.